### PR TITLE
Update Minimum OS Version for iOS so that emulator can be properly used

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>15.6</string>
 </dict>
 </plist>


### PR DESCRIPTION
Updated minimum iOS version from 12 to 15.6 so that I can run the iOS emulator from my laptop. 