### PR TITLE
Section cutter section creation

### DIFF
--- a/lib/create_test_form.dart
+++ b/lib/create_test_form.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:p2bp_2025spring_mobile/db_schema_classes.dart';
+import 'package:p2bp_2025spring_mobile/section_creation_page.dart';
 import 'package:p2bp_2025spring_mobile/standing_points_page.dart';
 
 class CreateTestForm extends StatefulWidget {
@@ -24,6 +25,7 @@ class _CreateTestFormState extends State<CreateTestForm> {
   List _standingPoints = [];
 
   bool _standingPointsTest = false;
+  String _standingPointType = '';
   bool _standingPointsError = false;
   bool _timerTest = false;
 
@@ -218,8 +220,16 @@ class _CreateTestFormState extends State<CreateTestForm> {
               onChanged: (value) {
                 _selectedTest = value;
                 setState(() {
+                  _standingPoints = [];
                   _standingPointsTest =
                       standingPointsTests.contains(_selectedTest);
+                  if (_selectedTest
+                          ?.compareTo(SectionCutterTest.collectionIDStatic) ==
+                      0) {
+                    _standingPointType = 'A Section Line';
+                  } else if (_standingPointsTest) {
+                    _standingPointType = 'Standing Points';
+                  }
                 });
               },
               autovalidateMode: AutovalidateMode.onUserInteraction,
@@ -239,16 +249,28 @@ class _CreateTestFormState extends State<CreateTestForm> {
                         flex: 2,
                         child: ElevatedButton(
                           onPressed: () async {
-                            final List tempPoints = await Navigator.push(
+                            final List tempPoints;
+                            tempPoints = await Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (context) => StandingPointsPage(
-                                  activeProject: widget.activeProject,
-                                  currentStandingPoints:
-                                      _standingPoints.isNotEmpty
-                                          ? _standingPoints
-                                          : null,
-                                ),
+                                builder: (context) => (_selectedTest?.compareTo(
+                                            SectionCutterTest
+                                                .collectionIDStatic) ==
+                                        0)
+                                    ? SectionCreationPage(
+                                        activeProject: widget.activeProject,
+                                        currentSection:
+                                            _standingPoints.isNotEmpty
+                                                ? _standingPoints
+                                                : null,
+                                      )
+                                    : StandingPointsPage(
+                                        activeProject: widget.activeProject,
+                                        currentStandingPoints:
+                                            _standingPoints.isNotEmpty
+                                                ? _standingPoints
+                                                : null,
+                                      ),
                               ),
                             );
                             setState(() {
@@ -266,8 +288,8 @@ class _CreateTestFormState extends State<CreateTestForm> {
                           ),
                           child: Text(
                             _standingPoints.isEmpty
-                                ? 'Add Standing Points'
-                                : 'Edit Standing Points',
+                                ? 'Add $_standingPointType'
+                                : 'Edit $_standingPointType',
                             style: TextStyle(color: Colors.white),
                           ),
                         ),
@@ -290,7 +312,8 @@ class _CreateTestFormState extends State<CreateTestForm> {
                 : SizedBox(),
             (_standingPointsError)
                 ? Center(
-                    child: Text('Please add standing points first.',
+                    child: Text(
+                        'Please add ${_standingPointType.toLowerCase()} first.',
                         style: TextStyle(color: Color(0xFFB3261E))),
                   )
                 : SizedBox(),

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -107,8 +107,12 @@ class Project {
 /// List containing all tests that make use of standing points.
 ///
 /// Used to check for test creation and saving.
+///
+/// Note: Section Cutter is considered a standing points test even though
+/// it uses a section line, not points.
 const Set<String> standingPointsTests = {
-  IdentifyingAccessTest.collectionIDStatic
+  IdentifyingAccessTest.collectionIDStatic,
+  SectionCutterTest.collectionIDStatic,
 };
 
 /// List containing all tests that make use of standing points.
@@ -856,6 +860,9 @@ class SectionCutterTest extends Test<Map<String, String>> {
   /// Static constant definition of collection ID for this test type.
   static const String collectionIDStatic = 'section_cutter_tests';
 
+  /// Line used for taking section. Standing point equivalent for this test.
+  List linePoints;
+
   /// Creates a new [SectionCutterTest] instance from the given arguments.
   ///
   /// This is private because the intended usage of this is through the
@@ -868,6 +875,7 @@ class SectionCutterTest extends Test<Map<String, String>> {
     required super.projectRef,
     required super.collectionID,
     required super.data,
+    required this.linePoints,
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
@@ -891,6 +899,7 @@ class SectionCutterTest extends Test<Map<String, String>> {
           projectRef: projectRef,
           collectionID: collectionID,
           data: newInitialDataDeepCopy(),
+          linePoints: standingPoints ?? [],
         );
     // Register for Map for Test.recreateFromDoc
     Test._recreateTestConstructors[collectionIDStatic] =
@@ -904,6 +913,7 @@ class SectionCutterTest extends Test<Map<String, String>> {
               creationTime: testDoc['creationTime'],
               maxResearchers: testDoc['maxResearchers'],
               isComplete: testDoc['isComplete'],
+              linePoints: testDoc['linePoints'],
             );
     // Register for Map for Test.getPage
     Test._pageBuilders[SectionCutterTest] = (project, test) => SectionCutter(
@@ -911,6 +921,8 @@ class SectionCutterTest extends Test<Map<String, String>> {
           activeTest: test as SectionCutterTest,
         );
     // Register for Map for Test.saveToFirestore
+    // Standing points are saved under line, as they will be made to create
+    // a polyline, instead of displayed as individual points.
     Test._saveToFirestoreFunctions[SectionCutterTest] = (test) async {
       await _firestore.collection(test.collectionID).doc(test.testID).set({
         'title': test.title,
@@ -921,6 +933,7 @@ class SectionCutterTest extends Test<Map<String, String>> {
         'creationTime': test.creationTime,
         'maxResearchers': test.maxResearchers,
         'isComplete': false,
+        'linePoints': (test as SectionCutterTest).linePoints,
       }, SetOptions(merge: true));
     };
   }

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -7,6 +7,7 @@ import 'package:p2bp_2025spring_mobile/absence_of_order_test.dart';
 import 'package:p2bp_2025spring_mobile/google_maps_functions.dart';
 import 'package:p2bp_2025spring_mobile/lighting_profile_test.dart';
 import 'package:p2bp_2025spring_mobile/section_cutter_test.dart';
+import 'package:p2bp_2025spring_mobile/theme.dart';
 import 'firestore_functions.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -993,20 +994,13 @@ class SectionCutterTest extends Test<Map<String, String>> {
 /// [bikeRack], [taxiAndRideShare], [parking], or [transportStation]
 enum AccessType { bikeRack, taxiAndRideShare, parking, transportStation }
 
-List<Object> accessObjects = [
-  List<BikeRack>,
-  List<TaxiAndRideShare>,
-  List<Parking>,
-  List<TransportStation>
-];
-
-// Realistically, these should all inherit from a parent class that has certain
-// constants, such as width, color, and cap. Also have an abstract method for
-// converting to Firestore.
-
 /// Interface for Access Types. All Access Types must implement this interface
 /// and its functions.
 abstract class AccessTypes {
+  // Constants for all access types:
+  static const Cap startCap = Cap.roundCap;
+  static const int polylineWidth = 3;
+
   /// Uses the class fields to create a [Map] that is able to be stored in
   /// Firestore easily.
   Map<String, dynamic> convertToFirestoreData();
@@ -1052,9 +1046,7 @@ class AccessData implements AccessTypes {
 /// Bike rack type for Identifying Access test. Enum type [bikeRack].
 class BikeRack implements AccessTypes {
   static const AccessType type = AccessType.bikeRack;
-  static const int polylineWidth = 3;
   static const Color color = Colors.black;
-  static const Cap startCap = Cap.roundCap;
   final int spots;
   final Polyline polyline;
   final double pathLength;
@@ -1080,9 +1072,7 @@ class BikeRack implements AccessTypes {
 /// [taxiAndRideShare].
 class TaxiAndRideShare implements AccessTypes {
   static const AccessType type = AccessType.taxiAndRideShare;
-  static const int polylineWidth = 3;
   static const Color color = Colors.black;
-  static const Cap startCap = Cap.roundCap;
   final Polyline polyline;
   final double pathLength;
 
@@ -1105,9 +1095,7 @@ class TaxiAndRideShare implements AccessTypes {
 /// Parking type for Identifying Access test. Enum type [parking].
 class Parking implements AccessTypes {
   static const AccessType type = AccessType.parking;
-  static const int polylineWidth = 3;
   static const Color color = Colors.black;
-  static const Cap startCap = Cap.roundCap;
   final int spots;
   final Polygon polygon;
   final Polyline polyline;
@@ -1142,9 +1130,7 @@ class Parking implements AccessTypes {
 /// [transportStation].
 class TransportStation implements AccessTypes {
   static const AccessType type = AccessType.transportStation;
-  static const int polylineWidth = 3;
   static const Color color = Colors.black;
-  static const Cap startCap = Cap.roundCap;
   final int routeNumber;
   final Polyline polyline;
   final double pathLength;
@@ -1294,8 +1280,8 @@ class IdentifyingAccessTest extends Test<AccessData> {
                       polylineId: PolylineId(
                           DateTime.now().millisecondsSinceEpoch.toString()),
                       color: BikeRack.color,
-                      width: BikeRack.polylineWidth,
-                      startCap: BikeRack.startCap,
+                      width: AccessTypes.polylineWidth,
+                      startCap: AccessTypes.startCap,
                       points: polylinePoints.toLatLngList(),
                     ),
                   ),
@@ -1313,8 +1299,8 @@ class IdentifyingAccessTest extends Test<AccessData> {
                       polylineId: PolylineId(
                           DateTime.now().millisecondsSinceEpoch.toString()),
                       color: TaxiAndRideShare.color,
-                      width: TaxiAndRideShare.polylineWidth,
-                      startCap: TaxiAndRideShare.startCap,
+                      width: AccessTypes.polylineWidth,
+                      startCap: AccessTypes.startCap,
                       points: polylinePoints.toLatLngList(),
                     ),
                   ),
@@ -1336,8 +1322,8 @@ class IdentifyingAccessTest extends Test<AccessData> {
                         polylineId: PolylineId(
                             DateTime.now().millisecondsSinceEpoch.toString()),
                         color: Parking.color,
-                        width: Parking.polylineWidth,
-                        startCap: Parking.startCap,
+                        width: AccessTypes.polylineWidth,
+                        startCap: AccessTypes.startCap,
                         points: polylinePoints.toLatLngList()),
                     polygon: Polygon(
                       polygonId: PolygonId(
@@ -1361,8 +1347,8 @@ class IdentifyingAccessTest extends Test<AccessData> {
                         polylineId: PolylineId(
                             DateTime.now().millisecondsSinceEpoch.toString()),
                         color: TransportStation.color,
-                        width: TransportStation.polylineWidth,
-                        startCap: TransportStation.startCap,
+                        width: AccessTypes.polylineWidth,
+                        startCap: AccessTypes.startCap,
                         points: polylinePoints.toLatLngList()),
                   ),
                 );
@@ -1502,7 +1488,13 @@ class NatureData implements NatureTypes {
 /// [vegetation].
 class Vegetation implements NatureTypes {
   static const NatureType natureType = NatureType.vegetation;
-  static const Color polygonColor = Color(0x6510FF30);
+  static const Map<VegetationType, Color> vegetationTypeToColor = {
+    VegetationType.native: VegetationColors.nativeGreen,
+    VegetationType.design: VegetationColors.designGreen,
+    VegetationType.openField: VegetationColors.openFieldGreen,
+    VegetationType.other: VegetationColors.otherGreen,
+  };
+  final Color polygonColor;
   final VegetationType vegetationType;
   final String? otherType;
   final Polygon polygon;
@@ -1518,7 +1510,9 @@ class Vegetation implements NatureTypes {
       required this.otherType})
       : polygonArea = (mp.SphericalUtil.computeArea(polygon.toMPLatLngList()) *
                 pow(feetPerMeter, 2))
-            .toDouble();
+            .toDouble(),
+        polygonColor = vegetationTypeToColor[vegetationType] ??
+            VegetationColors.otherGreen;
 
   @override
   Map<String, dynamic> convertToFirestoreData() {
@@ -1554,7 +1548,13 @@ class Vegetation implements NatureTypes {
 /// [waterBody].
 class WaterBody implements NatureTypes {
   static const NatureType natureType = NatureType.waterBody;
-  static const Color polygonColor = Color(0x651020FF);
+  static const Map<WaterBodyType, Color> waterBodyTypeToColor = {
+    WaterBodyType.ocean: WaterBodyColors.oceanBlue,
+    WaterBodyType.river: WaterBodyColors.riverBlue,
+    WaterBodyType.lake: WaterBodyColors.lakeBlue,
+    WaterBodyType.swamp: WaterBodyColors.swampBlue,
+  };
+  final Color polygonColor;
   final WaterBodyType waterBodyType;
   final Polygon polygon;
   final double polygonArea;
@@ -1562,7 +1562,8 @@ class WaterBody implements NatureTypes {
   WaterBody({required this.waterBodyType, required this.polygon})
       : polygonArea = (mp.SphericalUtil.computeArea(polygon.toMPLatLngList()) *
                 pow(feetPerMeter, 2))
-            .toDouble();
+            .toDouble(),
+        polygonColor = waterBodyTypeToColor[waterBodyType] ?? Colors.blue;
 
   @override
   Map<String, dynamic> convertToFirestoreData() {
@@ -1792,7 +1793,8 @@ class NaturePrevalenceTest extends Test<NatureData> {
                       polygonId: PolygonId(
                           DateTime.now().millisecondsSinceEpoch.toString()),
                       points: map['polygon'].toLatLngList(),
-                      fillColor: Vegetation.polygonColor,
+                      fillColor: Vegetation.vegetationTypeToColor[vegetation] ??
+                          VegetationColors.otherGreen,
                     ),
                   ),
                 );
@@ -1809,7 +1811,8 @@ class NaturePrevalenceTest extends Test<NatureData> {
                       polygonId: PolygonId(
                           DateTime.now().millisecondsSinceEpoch.toString()),
                       points: map['polygon'].toLatLngList(),
-                      fillColor: Vegetation.polygonColor,
+                      fillColor: Vegetation.vegetationTypeToColor[vegetation] ??
+                          VegetationColors.otherGreen,
                     ),
                   ),
                 );
@@ -1832,7 +1835,8 @@ class NaturePrevalenceTest extends Test<NatureData> {
                     polygonId: PolygonId(
                         DateTime.now().millisecondsSinceEpoch.toString()),
                     points: map['polygon'].toLatLngList(),
-                    fillColor: Vegetation.polygonColor,
+                    fillColor: WaterBody.waterBodyTypeToColor[waterBody] ??
+                        WaterBodyColors.nullBlue,
                   ),
                 ),
               );

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -1003,8 +1003,54 @@ List<Object> accessObjects = [
 // Realistically, these should all inherit from a parent class that has certain
 // constants, such as width, color, and cap. Also have an abstract method for
 // converting to Firestore.
+
+/// Interface for Access Types. All Access Types must implement this interface
+/// and its functions.
+abstract class AccessTypes {
+  /// Uses the class fields to create a [Map] that is able to be stored in
+  /// Firestore easily.
+  Map<String, dynamic> convertToFirestoreData();
+}
+
+class AccessData implements AccessTypes {
+  List<BikeRack> bikeRacks = [];
+  List<TaxiAndRideShare> taxisAndRideShares = [];
+  List<Parking> parkingStructures = [];
+  List<TransportStation> transportStations = [];
+
+  @override
+
+  /// Transforms data stored locally as a [List]s of access type objects to
+  /// Firestore format (represented by a [Map])
+  /// with String keys and any other needed changes.
+  Map<String, dynamic> convertToFirestoreData() {
+    Map<String, List> output = {
+      AccessType.bikeRack.name: [],
+      AccessType.taxiAndRideShare.name: [],
+      AccessType.parking.name: [],
+      AccessType.transportStation.name: [],
+    };
+
+    for (BikeRack bikeRack in bikeRacks) {
+      output[AccessType.bikeRack.name]?.add(bikeRack.convertToFirestoreData());
+    }
+    for (TaxiAndRideShare taxisAndRideShare in taxisAndRideShares) {
+      output[AccessType.taxiAndRideShare.name]
+          ?.add(taxisAndRideShare.convertToFirestoreData());
+    }
+    for (TransportStation transportStation in transportStations) {
+      output[AccessType.transportStation.name]
+          ?.add(transportStation.convertToFirestoreData());
+    }
+    for (Parking parking in parkingStructures) {
+      output[AccessType.parking.name]?.add(parking.convertToFirestoreData());
+    }
+    return output;
+  }
+}
+
 /// Bike rack type for Identifying Access test. Enum type [bikeRack].
-class BikeRack {
+class BikeRack implements AccessTypes {
   static const AccessType type = AccessType.bikeRack;
   static const int polylineWidth = 3;
   static const Color color = Colors.black;
@@ -1017,7 +1063,7 @@ class BikeRack {
       : pathLength = mp.SphericalUtil.computeLength(polyline.toMPLatLngList())
             .toDouble();
 
-  /// Returns a map with data that can be stored in Firestore easily.
+  @override
   Map<String, dynamic> convertToFirestoreData() {
     Map<String, dynamic> firestoreData = {
       'spots': spots,
@@ -1032,7 +1078,7 @@ class BikeRack {
 
 /// Taxi/ride share type for Identifying Access test. Enum type
 /// [taxiAndRideShare].
-class TaxiAndRideShare {
+class TaxiAndRideShare implements AccessTypes {
   static const AccessType type = AccessType.taxiAndRideShare;
   static const int polylineWidth = 3;
   static const Color color = Colors.black;
@@ -1044,7 +1090,7 @@ class TaxiAndRideShare {
       : pathLength = mp.SphericalUtil.computeLength(polyline.toMPLatLngList())
             .toDouble();
 
-  /// Returns a map with data that can be stored in Firestore easily.
+  @override
   Map<String, dynamic> convertToFirestoreData() {
     Map<String, dynamic> firestoreData = {
       'pathInfo': {
@@ -1057,7 +1103,7 @@ class TaxiAndRideShare {
 }
 
 /// Parking type for Identifying Access test. Enum type [parking].
-class Parking {
+class Parking implements AccessTypes {
   static const AccessType type = AccessType.parking;
   static const int polylineWidth = 3;
   static const Color color = Colors.black;
@@ -1075,7 +1121,7 @@ class Parking {
                 pow(feetPerMeter, 2))
             .toDouble();
 
-  /// Returns a map with data that can be stored in Firestore easily.
+  @override
   Map<String, dynamic> convertToFirestoreData() {
     Map<String, dynamic> firestoreData = {
       'spots': spots,
@@ -1085,7 +1131,7 @@ class Parking {
       },
       'polygonInfo': {
         'polygon': polygon.points.toGeoPointList(),
-        'polygonArea': pathLength,
+        'polygonArea': polygonArea,
       }
     };
     return firestoreData;
@@ -1094,7 +1140,7 @@ class Parking {
 
 /// Transport station type for Identifying Access test. Enum type
 /// [transportStation].
-class TransportStation {
+class TransportStation implements AccessTypes {
   static const AccessType type = AccessType.transportStation;
   static const int polylineWidth = 3;
   static const Color color = Colors.black;
@@ -1107,7 +1153,7 @@ class TransportStation {
       : pathLength = mp.SphericalUtil.computeLength(polyline.toMPLatLngList())
             .toDouble();
 
-  /// Returns a map with data that can be stored in Firestore easily.
+  @override
   Map<String, dynamic> convertToFirestoreData() {
     Map<String, dynamic> firestoreData = {
       'routeNumber': routeNumber,
@@ -1121,16 +1167,11 @@ class TransportStation {
 }
 
 /// Class for identifying access test info and methods.
-class IdentifyingAccessTest extends Test<Map> {
+class IdentifyingAccessTest extends Test<AccessData> {
   /// Returns a new instance of the initial data structure used for
   /// Identifying Access Test.
-  static Map<AccessType, List> newInitialDataDeepCopy() {
-    Map<AccessType, List> accessData = {};
-    accessData[AccessType.bikeRack] = [];
-    accessData[AccessType.taxiAndRideShare] = [];
-    accessData[AccessType.transportStation] = [];
-    accessData[AccessType.parking] = [];
-    return accessData;
+  static AccessData newInitialDataDeepCopy() {
+    return AccessData();
   }
 
   /// Static constant definition of collection ID for this test type.
@@ -1212,7 +1253,7 @@ class IdentifyingAccessTest extends Test<Map> {
   }
 
   @override
-  void submitData(Map data) async {
+  void submitData(AccessData data) async {
     // Adds all points of each type from submitted data to overall data
     Map firestoreData = convertDataToFirestore(data);
 
@@ -1232,14 +1273,12 @@ class IdentifyingAccessTest extends Test<Map> {
   /// Transforms data retrieved from Firestore test instance to
   /// a list of AccessType objects, with data accessed through the fields of
   /// the respective objects.
-  static Map<AccessType, dynamic> convertDataFromFirestore(
-      Map<String, dynamic> data) {
-    Map<AccessType, dynamic> output = newInitialDataDeepCopy();
+  static AccessData convertDataFromFirestore(Map<String, dynamic> data) {
+    AccessData accessData = newInitialDataDeepCopy();
     List<AccessType> types = AccessType.values;
     List dataList;
     // Adds all data to output one type at a time
     for (final type in types) {
-      output[type] = [];
       if (data.containsKey(type.name)) {
         dataList = data[type.name];
         switch (type) {
@@ -1248,7 +1287,7 @@ class IdentifyingAccessTest extends Test<Map> {
               if (bikeRackMap.containsKey('pathInfo') &&
                   bikeRackMap['pathInfo'].containsKey('path')) {
                 List polylinePoints = bikeRackMap['pathInfo']['path'];
-                output[type]?.add(
+                accessData.bikeRacks.add(
                   BikeRack(
                     spots: bikeRackMap['spots'],
                     polyline: Polyline(
@@ -1268,7 +1307,7 @@ class IdentifyingAccessTest extends Test<Map> {
               if (taxiRideShareMap.containsKey('pathInfo') &&
                   taxiRideShareMap['pathInfo'].containsKey('path')) {
                 List polylinePoints = taxiRideShareMap['pathInfo']['path'];
-                output[type]?.add(
+                accessData.taxisAndRideShares.add(
                   TaxiAndRideShare(
                     polyline: Polyline(
                       polylineId: PolylineId(
@@ -1290,7 +1329,7 @@ class IdentifyingAccessTest extends Test<Map> {
                       parkingMap['polygonInfo'].containsKey('polygon'))) {
                 List polylinePoints = parkingMap['pathInfo']['path'];
                 List polygonPoints = parkingMap['polygonInfo']['polygon'];
-                output[type]?.add(
+                accessData.parkingStructures.add(
                   Parking(
                     spots: parkingMap['spots'],
                     polyline: Polyline(
@@ -1315,7 +1354,7 @@ class IdentifyingAccessTest extends Test<Map> {
               if (transportStationMap.containsKey('pathInfo') &&
                   transportStationMap['pathInfo'].containsKey('path')) {
                 List polylinePoints = transportStationMap['pathInfo']['path'];
-                output[type]?.add(
+                accessData.transportStations.add(
                   TransportStation(
                     routeNumber: transportStationMap['routeNumber'],
                     polyline: Polyline(
@@ -1332,39 +1371,11 @@ class IdentifyingAccessTest extends Test<Map> {
         }
       }
     }
-    return output;
+    return accessData;
   }
 
-  /// Transforms data stored locally as a [List] of access type objects to
-  /// Firestore format (represented by a [Map])
-  /// with String keys and any other needed changes.
-  static Map<String, List> convertDataToFirestore(Map data) {
-    Map<String, List> output = {};
-    List<AccessType> types = AccessType.values;
-    for (final type in types) {
-      output[type.name] = [];
-      if (data.containsKey(type)) {
-        switch (type) {
-          case AccessType.bikeRack:
-            for (BikeRack accessObject in data[type]!) {
-              output[type.name]?.add(accessObject.convertToFirestoreData());
-            }
-          case AccessType.taxiAndRideShare:
-            for (TaxiAndRideShare accessObject in data[type]!) {
-              output[type.name]?.add(accessObject.convertToFirestoreData());
-            }
-          case AccessType.parking:
-            for (Parking accessObject in data[type]!) {
-              output[type.name]?.add(accessObject.convertToFirestoreData());
-            }
-          case AccessType.transportStation:
-            for (TransportStation accessObject in data[type]!) {
-              output[type.name]?.add(accessObject.convertToFirestoreData());
-            }
-        }
-      }
-    }
-    return output;
+  static Map convertDataToFirestore(AccessData accessData) {
+    return accessData.convertToFirestoreData();
   }
 }
 
@@ -1780,7 +1791,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
                     polygon: Polygon(
                       polygonId: PolygonId(
                           DateTime.now().millisecondsSinceEpoch.toString()),
-                      points: map['points'].toLatLngList(),
+                      points: map['polygon'].toLatLngList(),
                       fillColor: Vegetation.polygonColor,
                     ),
                   ),
@@ -1797,7 +1808,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
                     polygon: Polygon(
                       polygonId: PolygonId(
                           DateTime.now().millisecondsSinceEpoch.toString()),
-                      points: map['points'].toLatLngList(),
+                      points: map['polygon'].toLatLngList(),
                       fillColor: Vegetation.polygonColor,
                     ),
                   ),
@@ -1820,7 +1831,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
                   polygon: Polygon(
                     polygonId: PolygonId(
                         DateTime.now().millisecondsSinceEpoch.toString()),
-                    points: map['points'].toLatLngList(),
+                    points: map['polygon'].toLatLngList(),
                     fillColor: Vegetation.polygonColor,
                   ),
                 ),

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -861,7 +861,6 @@ class SectionCutterTest extends Test<Section> {
   /// Default structure for Section Cutter test. Simply a [Map<String, String>],
   /// where the first string is the field and the second is the reference which
   /// refers to the path of the section drawing.
-  static const Map<String, String> initialDataStructure = {"sectionLink": " "};
   static Section newInitialDataDeepCopy() {
     return Section(
         sectionLink: 'Empty sectionLink. SectionLink has not been set yet.');
@@ -939,7 +938,7 @@ class SectionCutterTest extends Test<Section> {
         'id': test.testID,
         'scheduledTime': test.scheduledTime,
         'project': test.projectRef,
-        'data': test.data,
+        'data': convertDataToFirestore(test.data),
         'creationTime': test.creationTime,
         'maxResearchers': test.maxResearchers,
         'isComplete': false,

--- a/lib/firestore_functions.dart
+++ b/lib/firestore_functions.dart
@@ -620,6 +620,9 @@ extension DynamicLatLngExtraction on List<dynamic> {
       if (coordinate.runtimeType == GeoPoint) {
         newLatLngList.add(LatLng(coordinate.latitude, coordinate.longitude));
       }
+      if (coordinate.runtimeType == LatLng) {
+        newLatLngList.add(coordinate);
+      }
     });
     return newLatLngList;
   }

--- a/lib/google_maps_functions.dart
+++ b/lib/google_maps_functions.dart
@@ -56,7 +56,8 @@ Future<LocationPermission> _checkLocationPermissions() async {
 /// polygon out of those points (makes sure the polygon is logical). Returns
 /// the singular polygon as a Set so it can be used directly on the GoogleMap
 /// widget.
-Set<Polygon> finalizePolygon(List<LatLng> polygonPoints) {
+Set<Polygon> finalizePolygon(List<LatLng> polygonPoints,
+    [Color? polygonColor]) {
   Set<Polygon> polygon = {};
   try {
     // Sort points in clockwise order
@@ -69,9 +70,9 @@ Set<Polygon> finalizePolygon(List<LatLng> polygonPoints) {
       Polygon(
         polygonId: PolygonId(polygonId),
         points: sortedPoints,
-        strokeColor: Colors.blue,
+        strokeColor: polygonColor ?? Colors.blue,
         strokeWidth: 2,
-        fillColor: Colors.blue.withValues(alpha: 0.2),
+        fillColor: polygonColor ?? Colors.blue.withValues(alpha: 0.2),
       ),
     };
   } catch (e, stacktrace) {

--- a/lib/google_maps_functions.dart
+++ b/lib/google_maps_functions.dart
@@ -75,7 +75,7 @@ Set<Polygon> finalizePolygon(List<LatLng> polygonPoints) {
       ),
     };
   } catch (e, stacktrace) {
-    print('Excpetion in finalize_polygon(): $e');
+    print('Exception in finalize_polygon(): $e');
     print('Stacktrace: $stacktrace');
   }
   return polygon;
@@ -168,14 +168,37 @@ Polyline? createPolyline(List<LatLng> polylinePoints, Color color) {
 
     polyline = Polyline(
       polylineId: PolylineId(polylineID),
-      width: 3,
-      startCap: Cap.roundCap,
+      width: 4,
+      startCap: Cap.squareCap,
       points: polylinePoints,
       color: color,
     );
   } catch (e, stacktrace) {
-    print('Excpetion in finalize_polygon(): $e');
+    print('Exception in finalize_polygon(): $e');
     print('Stacktrace: $stacktrace');
   }
   return polyline;
+}
+
+/// Gets the the rectangle bounds enclosing a polygon.
+///
+/// Takes a list of [LatLng] points and returns a [LatLngBounds]. If bounds
+/// cannot be created (eg. points is empty) then returns null.
+LatLngBounds? getLatLngBounds(List<LatLng> points) {
+  LatLng southWest;
+  LatLng northEast;
+
+  if (points.isEmpty || points.firstOrNull == null) return null;
+
+  southWest = points.first;
+  northEast = points.first;
+
+  for (LatLng point in points) {
+    southWest = LatLng(min(point.latitude, southWest.latitude),
+        min(point.longitude, southWest.longitude));
+    northEast = LatLng(max(point.latitude, northEast.latitude),
+        max(point.longitude, northEast.longitude));
+  }
+
+  return LatLngBounds(southwest: southWest, northeast: northEast);
 }

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -888,16 +888,20 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
   void _finalizePolygon() {
     Set<Polygon> tempPolygon;
     try {
-      tempPolygon = finalizePolygon(_polygonPoints);
-      // Create polygon.
-      _polygons = {..._polygons, ...tempPolygon};
-
       if (_natureType == NatureType.vegetation) {
+        tempPolygon = finalizePolygon(
+            _polygonPoints, Vegetation.vegetationTypeToColor[_vegetationType]);
+        // Create polygon.
+        _polygons = {..._polygons, ...tempPolygon};
         vegetationData.add(Vegetation(
             vegetationType: _vegetationType!,
             polygon: tempPolygon.first,
             otherType: _otherType));
       } else if (_natureType == NatureType.waterBody) {
+        tempPolygon = finalizePolygon(
+            _polygonPoints, WaterBody.waterBodyTypeToColor[_waterBodyType]);
+        // Create polygon.
+        _polygons = {..._polygons, ...tempPolygon};
         waterBodyData.add(WaterBody(
             waterBodyType: _waterBodyType!, polygon: tempPolygon.first));
       } else {

--- a/lib/project_details_page.dart
+++ b/lib/project_details_page.dart
@@ -369,37 +369,42 @@ class TestCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(10.0),
-        child: Row(
-          children: <Widget>[
-            // TODO: change corresponding to test type
-            CircleAvatar(
-              child: Text(_testInitialsMap[test.runtimeType] ?? ''),
-            ),
-            SizedBox(width: 15),
-            Expanded(
-              child: Text(test.title),
-            ),
-            Align(
-              alignment: Alignment.centerRight,
-              child: IconButton(
-                icon: const Icon(
-                  Icons.chevron_right,
-                  color: Colors.blue,
-                ),
-                tooltip: 'Open team settings',
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => test.getPage(project)),
-                  );
-                },
+    return InkWell(
+      onLongPress: () {
+        print('1');
+      },
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Row(
+            children: <Widget>[
+              // TODO: change corresponding to test type
+              CircleAvatar(
+                child: Text(_testInitialsMap[test.runtimeType] ?? ''),
               ),
-            ),
-          ],
+              SizedBox(width: 15),
+              Expanded(
+                child: Text(test.title),
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: IconButton(
+                  icon: const Icon(
+                    Icons.chevron_right,
+                    color: Colors.blue,
+                  ),
+                  tooltip: 'Open team settings',
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => test.getPage(project)),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/section_creation_page.dart
+++ b/lib/section_creation_page.dart
@@ -1,0 +1,263 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:p2bp_2025spring_mobile/theme.dart';
+import 'google_maps_functions.dart';
+import 'db_schema_classes.dart';
+import 'firestore_functions.dart';
+
+class SectionCreationPage extends StatefulWidget {
+  final Project activeProject;
+  final List? currentSection;
+  const SectionCreationPage(
+      {super.key, required this.activeProject, this.currentSection});
+
+  @override
+  State<SectionCreationPage> createState() => _SectionCreationPageState();
+}
+
+class _SectionCreationPageState extends State<SectionCreationPage> {
+  DocumentReference? teamRef;
+  GoogleMapController? mapController;
+  LatLng _location = defaultLocation; // Default location
+  bool _isLoading = true;
+  String _directions = "Create your section by marking two points.";
+  Set<Polygon> _polygons = {}; // Set of polygons
+  Set<Marker> _markers = {}; // Set of markers for points
+  MapType _currentMapType = MapType.satellite; // Default map type
+  Project? project;
+  Set<Polyline> _polyline = {};
+  LatLng? _currentPoint;
+  bool _sectionSet = false;
+
+  @override
+  void initState() {
+    super.initState();
+    initProjectArea();
+  }
+
+  /// Gets the project polygon, adds it to the current polygon list, and
+  /// centers the map over it.
+  void initProjectArea() {
+    setState(() {
+      _polygons = getProjectPolygon(widget.activeProject.polygonPoints);
+      _location = getPolygonCentroid(_polygons.first);
+      // Take some latitude away to center considering bottom sheet.
+      _location = LatLng(_location.latitude * .999999, _location.longitude);
+      // TODO: dynamic zooming
+      if (widget.currentSection != null) {
+        final List? currentSection = widget.currentSection;
+        _loadCurrentSection(currentSection);
+      }
+      _isLoading = false;
+    });
+  }
+
+  void _loadCurrentSection(List? currentSection) {
+    final Polyline? polyline =
+        createPolyline(currentSection!.toLatLngList(), Colors.green[600]!);
+    if (polyline == null) return;
+    setState(() {
+      _polyline = {polyline};
+    });
+  }
+
+  void _polylineTap(LatLng point) {
+    if (_sectionSet) return;
+    final MarkerId markerId = MarkerId('marker_${point.toString()}');
+    setState(() {
+      _markers.add(
+        Marker(
+          markerId: markerId,
+          position: point,
+          consumeTapEvents: true,
+          onTap: () {
+            // If the marker is tapped again, it will be removed
+            setState(() {
+              _currentPoint = null;
+              _markers.removeWhere((marker) => marker.markerId == markerId);
+            });
+          },
+        ),
+      );
+      if (_currentPoint == null) return;
+      final Polyline? polyline =
+          createPolyline([_currentPoint!, point], Colors.green[600]!);
+      if (polyline == null) return;
+      if (_markers.length == 2) _markers = {};
+      _polyline = {polyline};
+      _sectionSet = true;
+      _directions =
+          'Section set. Click confirm to save, or delete and start over.';
+    });
+    _currentPoint = point;
+  }
+
+  void _onMapCreated(GoogleMapController controller) {
+    mapController = controller;
+    _moveToLocation(); // Ensure the map is centered on the current location
+  }
+
+  void _moveToLocation() {
+    if (mapController == null) return;
+    mapController!.animateCamera(
+      CameraUpdate.newCameraPosition(
+        CameraPosition(target: _location, zoom: 14.0),
+      ),
+    );
+  }
+
+  void _toggleMapType() {
+    setState(() {
+      _currentMapType = (_currentMapType == MapType.normal
+          ? MapType.satellite
+          : MapType.normal);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        body: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Stack(
+                children: [
+                  SizedBox(
+                    height: MediaQuery.of(context).size.height,
+                    child: Stack(
+                      children: [
+                        GoogleMap(
+                          onMapCreated: _onMapCreated,
+                          initialCameraPosition:
+                              CameraPosition(target: _location, zoom: 14.0),
+                          polygons: _polygons,
+                          polylines: _polyline,
+                          markers: _markers,
+                          mapType: _currentMapType, // Use current map type
+                          onTap: _polylineTap,
+                        ),
+                        Align(
+                          alignment: Alignment.topCenter,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 20.0, horizontal: 25.0),
+                            child: Container(
+                              padding: EdgeInsets.symmetric(
+                                  horizontal: 15, vertical: 10),
+                              decoration: BoxDecoration(
+                                color: directionsTransparency,
+                                gradient: defaultGrad,
+                                borderRadius:
+                                    const BorderRadius.all(Radius.circular(10)),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: Colors.black.withValues(alpha: 0.1),
+                                    blurRadius: 6,
+                                    offset: const Offset(0, 2),
+                                  ),
+                                ],
+                              ),
+                              child: Text(
+                                _directions,
+                                maxLines: 3,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w500,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        Align(
+                          alignment: Alignment.bottomLeft,
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                                left: 10.0, bottom: 130.0),
+                            child: FloatingActionButton(
+                              tooltip: 'Clear all.',
+                              heroTag: null,
+                              onPressed: () {
+                                setState(() {
+                                  _markers = {};
+                                  _currentPoint = null;
+                                  _polyline = {};
+                                  _sectionSet = false;
+                                  _directions =
+                                      "Create your section by marking two points. Then click the check to confirm.";
+                                });
+                              },
+                              backgroundColor: Colors.red,
+                              child: Icon(
+                                Icons.delete_sweep,
+                                size: 30,
+                              ),
+                            ),
+                          ),
+                        ),
+                        Align(
+                          alignment: Alignment.bottomLeft,
+                          child: Padding(
+                            padding: EdgeInsets.only(left: 10.0, bottom: 50),
+                            child: FloatingActionButton(
+                              tooltip: 'Change map type.',
+                              onPressed: _toggleMapType,
+                              backgroundColor: Colors.green,
+                              child: const Icon(Icons.map),
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: EdgeInsets.only(bottom: 5),
+                          child: Align(
+                            alignment: Alignment.bottomCenter,
+                            child: FilledButton.icon(
+                              style: FilledButton.styleFrom(
+                                padding:
+                                    const EdgeInsets.only(left: 15, right: 15),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(15.0),
+                                ),
+                                elevation: 3.0,
+                                shadowColor: Colors.black,
+                                foregroundColor: Colors.white,
+                                backgroundColor: Colors.black,
+                                iconColor: Colors.white,
+                                disabledBackgroundColor: disabledGrey,
+                              ),
+                              onPressed: _isLoading
+                                  ? null
+                                  : () {
+                                      try {
+                                        setState(() {
+                                          _isLoading = true;
+                                        });
+                                        Navigator.pop(
+                                            context,
+                                            _polyline.isEmpty
+                                                ? null
+                                                : _polyline.single.points
+                                                    .toGeoPointList());
+                                      } catch (e, stacktrace) {
+                                        print(
+                                            "Exception in confirming section (section_creation_point.dart): $e");
+                                        print("Stacktrace: $stacktrace");
+                                      }
+                                    },
+                              label: Text('Confirm'),
+                              icon: const Icon(Icons.check),
+                              iconAlignment: IconAlignment.end,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -375,8 +375,7 @@ class _SectionCutterState extends State<SectionCutter> {
                                         setState(() {
                                           _isLoadingUpload = true;
                                         });
-                                        Map<String, String> data = await widget
-                                            .activeTest!
+                                        Section data = await widget.activeTest!
                                             .saveXFile(sectionCutterFile!);
                                         widget.activeTest!.submitData(data);
                                         if (!context.mounted) return;

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:p2bp_2025spring_mobile/firestore_functions.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
 import 'package:p2bp_2025spring_mobile/widgets.dart';
 import 'project_details_page.dart';
@@ -44,10 +45,14 @@ class _SectionCutterState extends State<SectionCutter> {
   LatLng _location = defaultLocation; // Default location
   SectionCutterTest? currentTest;
   Set<Polygon> _polygons = {}; // Set of polygons
+  Set<Polyline> _polyline = {};
+  List<LatLng> _sectionPoints = [];
 
   MapType _currentMapType = MapType.satellite; // Default map type
 
   Project? project;
+
+  double _zoom = 14;
 
   @override
   void initState() {
@@ -64,7 +69,16 @@ class _SectionCutterState extends State<SectionCutter> {
       // Take some lattitude away to center considering bottom sheet.
       _location = LatLng(_location.latitude * .999999, _location.longitude);
       // TODO: dynamic zooming
-      // get test polyline
+      _sectionPoints = widget.activeTest!.linePoints.toLatLngList();
+      _polyline = {
+        Polyline(
+          polylineId:
+              PolylineId(DateTime.now().millisecondsSinceEpoch.toString()),
+          points: _sectionPoints,
+          color: Colors.green,
+          width: 4,
+        )
+      };
     });
   }
 
@@ -76,7 +90,7 @@ class _SectionCutterState extends State<SectionCutter> {
   void _moveToLocation() {
     mapController.animateCamera(
       CameraUpdate.newCameraPosition(
-        CameraPosition(target: _location, zoom: 14),
+        CameraPosition(target: _location, zoom: _zoom),
       ),
     );
   }
@@ -107,8 +121,11 @@ class _SectionCutterState extends State<SectionCutter> {
                         padding: EdgeInsets.only(bottom: _bottomSheetHeight),
                         onMapCreated: _onMapCreated,
                         initialCameraPosition:
-                            CameraPosition(target: _location, zoom: 14),
+                            CameraPosition(target: _location, zoom: _zoom),
+                        cameraTargetBounds: CameraTargetBounds(
+                            getLatLngBounds(_polyline.single.points)),
                         polygons: _polygons,
+                        polylines: _polyline,
                         mapType: _currentMapType, // Use current map type
                       ),
                     ),

--- a/lib/standing_points_page.dart
+++ b/lib/standing_points_page.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
@@ -17,7 +16,6 @@ class StandingPointsPage extends StatefulWidget {
   State<StandingPointsPage> createState() => _StandingPointsPageState();
 }
 
-final User? loggedInUser = FirebaseAuth.instance.currentUser;
 final AssetMapBitmap disabledIcon = AssetMapBitmap(
   'assets/standing_point_disabled_marker.png',
   width: 45,
@@ -34,7 +32,7 @@ class _StandingPointsPageState extends State<StandingPointsPage> {
   GoogleMapController? mapController;
   LatLng _location = defaultLocation; // Default location
   bool _isLoading = true;
-  String _directions =
+  final String _directions =
       "Select the standing points you want to use in this test. Then click confirm.";
   Set<Polygon> _polygons = {}; // Set of polygons
   Set<Marker> _markers = {}; // Set of markers for points

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -11,6 +11,25 @@ const Color directionsTransparency = Color(0xDFDDE6F2);
 /// Default yellow color, used mainly for text on blue gradient background.
 const Color placeYellow = Color(0xFFFFD31F);
 
+/// Colors used for Vegetation in Nature Prevalence Test
+class VegetationColors {
+  static const Color nativeGreen = Color(0x6508AC12);
+  static const Color designGreen = Color(0x656DFD75);
+  static const Color openFieldGreen = Color(0x65C7FF80);
+  static const Color otherGreen = Color(0x6C00FF3C);
+}
+
+/// Colors used for Bodies of Water in Nature Prevalence Test
+class WaterBodyColors {
+  static const Color oceanBlue = Color(0x651020FF);
+  static const Color riverBlue = Color(0x656253EA);
+  static const Color lakeBlue = Color(0x652FB3DD);
+  static const Color swampBlue = Color(0x65009595);
+
+  /// Used if retrieval from class map is null (should only be used if error)
+  static const Color nullBlue = Color(0x934800FF);
+}
+
 const LinearGradient defaultGrad = LinearGradient(
   begin: Alignment.topLeft,
   end: Alignment.bottomRight,


### PR DESCRIPTION
This merge brings in the Section Cutter 'standing points' (section line) update. It adds the ability for uses to create section lines during Section Cutter test creation, and see those lines when they complete their test.

It also adds a restructuring for both the Identifying Access and Section Cutter implementations to use classes. While Section Cutter was previously a relatively simple implementation (and still is), it has been changed to fall in line with the other tests. Identifying Access now has a parent class which the test takes as a data type. This should make data retrieval much easier.

Added a color map to Nature Prevalence for dynamic coloring of polygons. Required changing finalizePolygon() function in google_maps_functions.dart to take optional color parameter.

Changed Identifying Access to require route number/spots to continue during test. Also required two points for polyline confirmation and three for polygon confirmation.