### PR TITLE
Timer and Test Changes

### DIFF
--- a/lib/create_test_form.dart
+++ b/lib/create_test_form.dart
@@ -161,7 +161,7 @@ class _CreateTestFormState extends State<CreateTestForm> {
             _timerTest
                 ? TextFormField(
                     decoration: InputDecoration(
-                      labelText: 'Timer Time (mm:ss)',
+                      labelText: 'Test Duration (mm:ss)',
                       hintText: 'mm:ss',
                       floatingLabelBehavior: FloatingLabelBehavior.always,
                       labelStyle: TextStyle(color: Color(0xFF2F6DCF)),

--- a/lib/create_test_form.dart
+++ b/lib/create_test_form.dart
@@ -5,7 +5,6 @@ import 'package:flutter/services.dart';
 import 'package:p2bp_2025spring_mobile/db_schema_classes.dart';
 import 'package:p2bp_2025spring_mobile/section_creation_page.dart';
 import 'package:p2bp_2025spring_mobile/standing_points_page.dart';
-import 'package:p2bp_2025spring_mobile/widgets.dart';
 
 class CreateTestForm extends StatefulWidget {
   final Project activeProject;
@@ -159,6 +158,41 @@ class _CreateTestFormState extends State<CreateTestForm> {
               },
             ),
             SizedBox(height: 16),
+            _timerTest
+                ? TextFormField(
+                    decoration: InputDecoration(
+                      labelText: 'Timer Time (mm:ss)',
+                      hintText: 'mm:ss',
+                      floatingLabelBehavior: FloatingLabelBehavior.always,
+                      labelStyle: TextStyle(color: Color(0xFF2F6DCF)),
+                      floatingLabelStyle: TextStyle(color: Color(0xFF1A3C70)),
+                      enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Color(0xFF2F6DCF))),
+                      focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Color(0xFF1A3C70))),
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: (value) {
+                      if (value.length != 5) return;
+                      int? seconds;
+                      int? minutes;
+                      seconds = int.tryParse(value.substring(3)) ?? 0;
+                      minutes = int.tryParse(value.substring(0, 2)) ?? 0;
+                      seconds += minutes * 60;
+                      _timerSeconds = seconds;
+                    },
+                    inputFormatters: [MinSecondsFormatter()],
+                    keyboardType: TextInputType.number,
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Set a time for the timer. Format as mm:ss.';
+                      }
+                      return null;
+                    },
+                  )
+                : SizedBox(),
+            SizedBox(height: _timerTest ? 16 : 0),
             // Dropdown menu for selecting an activity
             DropdownButtonFormField2<String>(
               decoration: InputDecoration(
@@ -265,40 +299,6 @@ class _CreateTestFormState extends State<CreateTestForm> {
               },
             ),
             SizedBox(height: 16),
-            _timerTest
-                ? TextFormField(
-                    decoration: InputDecoration(
-                      labelText: 'Timer Time (mm:ss)',
-                      hintText: 'mm:ss',
-                      floatingLabelBehavior: FloatingLabelBehavior.always,
-                      labelStyle: TextStyle(color: Color(0xFF2F6DCF)),
-                      floatingLabelStyle: TextStyle(color: Color(0xFF1A3C70)),
-                      enabledBorder: OutlineInputBorder(
-                          borderSide: BorderSide(color: Color(0xFF2F6DCF))),
-                      focusedBorder: OutlineInputBorder(
-                          borderSide: BorderSide(color: Color(0xFF1A3C70))),
-                      border: OutlineInputBorder(),
-                    ),
-                    onChanged: (value) {
-                      if (value.length != 5) return;
-                      int? seconds;
-                      int? minutes;
-                      seconds = int.tryParse(value.substring(3)) ?? 0;
-                      minutes = int.tryParse(value.substring(0, 2)) ?? 0;
-                      seconds += minutes * 60;
-                      _timerSeconds = seconds;
-                    },
-                    inputFormatters: [MinSecondsFormatter()],
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    validator: (value) {
-                      if (value == null || value.isEmpty) {
-                        return 'Set a time for the timer. Format as mm:ss.';
-                      }
-                      return null;
-                    },
-                  )
-                : SizedBox(),
-            SizedBox(height: _timerTest ? 16 : 0),
             _standingPointsTest
                 ? Row(
                     children: [

--- a/lib/create_test_form.dart
+++ b/lib/create_test_form.dart
@@ -1,9 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:flutter/services.dart';
 import 'package:p2bp_2025spring_mobile/db_schema_classes.dart';
 import 'package:p2bp_2025spring_mobile/section_creation_page.dart';
 import 'package:p2bp_2025spring_mobile/standing_points_page.dart';
+import 'package:p2bp_2025spring_mobile/widgets.dart';
 
 class CreateTestForm extends StatefulWidget {
   final Project activeProject;
@@ -21,6 +23,7 @@ class _CreateTestFormState extends State<CreateTestForm> {
 
   DateTime? _selectedDateTime;
   String? _selectedTest;
+  int? _timerSeconds;
 
   List _standingPoints = [];
 
@@ -243,6 +246,7 @@ class _CreateTestFormState extends State<CreateTestForm> {
                 _standingPoints = [];
                 setState(() {
                   _standingPointsTest = Test.isStandingPointTest(_selectedTest);
+                  _timerTest = Test.isTimerTest(_selectedTest);
                   if (_selectedTest
                           ?.compareTo(SectionCutterTest.collectionIDStatic) ==
                       0) {
@@ -260,11 +264,45 @@ class _CreateTestFormState extends State<CreateTestForm> {
                 return null;
               },
             ),
-            SizedBox(height: 32),
+            SizedBox(height: 16),
+            _timerTest
+                ? TextFormField(
+                    decoration: InputDecoration(
+                      labelText: 'Timer Time (mm:ss)',
+                      hintText: 'mm:ss',
+                      floatingLabelBehavior: FloatingLabelBehavior.always,
+                      labelStyle: TextStyle(color: Color(0xFF2F6DCF)),
+                      floatingLabelStyle: TextStyle(color: Color(0xFF1A3C70)),
+                      enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Color(0xFF2F6DCF))),
+                      focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Color(0xFF1A3C70))),
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: (value) {
+                      if (value.length != 5) return;
+                      int? seconds;
+                      int? minutes;
+                      seconds = int.tryParse(value.substring(3)) ?? 0;
+                      minutes = int.tryParse(value.substring(0, 2)) ?? 0;
+                      seconds += minutes * 60;
+                      _timerSeconds = seconds;
+                    },
+                    inputFormatters: [MinSecondsFormatter()],
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Set a time for the timer. Format as mm:ss.';
+                      }
+                      return null;
+                    },
+                  )
+                : SizedBox(),
+            SizedBox(height: _timerTest ? 16 : 0),
             _standingPointsTest
                 ? Row(
                     children: [
-                      Spacer(flex: 1),
+                      Spacer(),
                       Expanded(
                         flex: 2,
                         child: ElevatedButton(
@@ -366,6 +404,11 @@ class _CreateTestFormState extends State<CreateTestForm> {
                           'standingPoints', (value) => _standingPoints,
                           ifAbsent: () => _standingPoints);
                     }
+                    if (_timerTest) {
+                      newTestInfo.update(
+                          'testDuration', (value) => _timerSeconds,
+                          ifAbsent: () => _timerSeconds);
+                    }
                     // Handle form submission
                     Navigator.of(context).pop(newTestInfo);
                   }
@@ -382,6 +425,66 @@ class _CreateTestFormState extends State<CreateTestForm> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class MinSecondsFormatter extends TextInputFormatter {
+  RegExp pattern = RegExp(r'^[0-9:]+$');
+
+  String formatMMSS(String value) {
+    if (value.length != 4) return value;
+    return '${value.substring(0, 2)}:${value.substring(2, 4)}';
+  }
+
+  String getRawInput(String value) {
+    return value.replaceAll(':', '');
+  }
+
+  String fillWithZeros(String value) {
+    if (value.length >= 4) return value;
+    final int emptySpaces = 4 - value.length;
+    return ('0' * emptySpaces) + value;
+  }
+
+  String restrictInput(String value) {
+    if (value.length <= 4) return value;
+    if (value[0] != '0') return value.substring(0, 4);
+    return value.substring(value.length - 4, value.length);
+  }
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    if (!pattern.hasMatch(newValue.text)) return oldValue;
+
+    TextSelection newSelection = newValue.selection;
+
+    String rawText;
+    String newText = newValue.text;
+
+    rawText = '';
+    if (newText.length < 5) {
+      if (newText == '00:0') {
+        rawText = '';
+      } else {
+        rawText = formatMMSS(fillWithZeros(getRawInput(newText)));
+      }
+    } else if (newText.length == 6) {
+      rawText = formatMMSS(restrictInput(getRawInput(newText)));
+    }
+
+    newSelection = newValue.selection.copyWith(
+      baseOffset: rawText.length,
+      extentOffset: rawText.length,
+    );
+
+    return TextEditingValue(
+      text: rawText,
+      selection: newSelection,
+      composing: TextRange.empty,
     );
   }
 }

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -240,6 +240,7 @@ abstract class Test<T> {
         required DocumentReference projectRef,
         required String collectionID,
         List? standingPoints,
+        int? testDuration,
       })> _newTestConstructors = {};
 
   /// Maps from collection ID to a function which should use a constructor
@@ -281,7 +282,8 @@ abstract class Test<T> {
       required Timestamp scheduledTime,
       required DocumentReference projectRef,
       required String collectionID,
-      List? standingPoints}) {
+      List? standingPoints,
+      int? testDuration}) {
     final constructor = _newTestConstructors[collectionID];
 
     if (constructor != null) {
@@ -292,6 +294,7 @@ abstract class Test<T> {
         projectRef: projectRef,
         collectionID: collectionID,
         standingPoints: standingPoints,
+        testDuration: testDuration,
       );
     }
     throw Exception('Unregistered Test type for collection: $collectionID');
@@ -339,6 +342,12 @@ abstract class Test<T> {
   /// registered as a standing points test.
   static bool isStandingPointTest(String? collectionID) {
     return _standingPointTestCollectionIDs.contains(collectionID);
+  }
+
+  /// Returns whether [Test] subclass with given [collectionID] is
+  /// registered as a timer test.
+  static bool isTimerTest(String? collectionID) {
+    return _timerTestCollectionIDs.contains(collectionID);
   }
 
   @override
@@ -474,6 +483,8 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
   /// Static constant definition of collection ID for this test type.
   static const String collectionIDStatic = 'lighting_profile_tests';
 
+  final int testDuration;
+
   /// Creates a new [LightingProfileTest] instance from the given arguments.
   ///
   /// This is private because the intended usage of this is through the
@@ -489,19 +500,20 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
+    required this.testDuration,
   }) : super._();
 
   /// Registers this class within the Maps required by class [Test].
   static void register() {
     // Register for creating new Lighting Profile Tests
-    Test._newTestConstructors[collectionIDStatic] = ({
-      required String title,
-      required String testID,
-      required Timestamp scheduledTime,
-      required DocumentReference projectRef,
-      required String collectionID,
-      List? standingPoints,
-    }) =>
+    Test._newTestConstructors[collectionIDStatic] = (
+            {required String title,
+            required String testID,
+            required Timestamp scheduledTime,
+            required DocumentReference projectRef,
+            required String collectionID,
+            List? standingPoints,
+            int? testDuration}) =>
         LightingProfileTest._(
           title: title,
           testID: testID,
@@ -509,6 +521,7 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
           projectRef: projectRef,
           collectionID: collectionID,
           data: LightingProfileData(),
+          testDuration: testDuration ?? -1,
         );
     // Register for recreating a Lighting Profile Test from Firestore
     Test._recreateTestConstructors[collectionIDStatic] = (testDoc) {
@@ -564,6 +577,7 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
       creationTime: doc['creationTime'],
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
+      testDuration: doc['testDuration'],
     );
   }
 
@@ -578,6 +592,7 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
       'creationTime': creationTime,
       'maxResearchers': maxResearchers,
       'isComplete': isComplete,
+      'testDuration': testDuration,
     };
   }
 }
@@ -817,6 +832,8 @@ class AbsenceOfOrderData with JsonToString {
 class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
   static const String collectionIDStatic = 'absence_of_order_tests';
 
+  final int testDuration;
+
   /// Creates a new [AbsenceOfOrderTest] instance from the given arguments.
   ///
   /// This is private because the intended usage of this is through the
@@ -829,6 +846,7 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
     required super.projectRef,
     required super.collectionID,
     required super.data,
+    required this.testDuration,
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
@@ -844,6 +862,7 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         AbsenceOfOrderTest._(
           title: title,
@@ -852,6 +871,7 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
           projectRef: projectRef,
           collectionID: collectionID,
           data: AbsenceOfOrderData(),
+          testDuration: testDuration ?? -1,
         );
     // Register for recreating an Absence of Order Test from Firestore
     Test._recreateTestConstructors[collectionIDStatic] = (testDoc) {
@@ -912,6 +932,7 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
       creationTime: doc['creationTime'],
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
+      testDuration: doc['testDuration'],
     );
   }
 
@@ -931,6 +952,7 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
       'creationTime': creationTime,
       'maxResearchers': maxResearchers,
       'isComplete': isComplete,
+      'testDuration': testDuration,
     };
   }
 }
@@ -1137,6 +1159,8 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
     with JsonToString {
   static const String collectionIDStatic = 'spatial_boundaries_tests';
 
+  final int testDuration;
+
   SpatialBoundariesTest._({
     required super.title,
     required super.testID,
@@ -1144,6 +1168,7 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
     required super.projectRef,
     required super.collectionID,
     required super.data,
+    required this.testDuration,
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
@@ -1159,6 +1184,7 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         SpatialBoundariesTest._(
           title: title,
@@ -1167,6 +1193,7 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
           projectRef: projectRef,
           collectionID: collectionID,
           data: SpatialBoundariesData(),
+          testDuration: testDuration ?? -1,
         );
     // Register for recreating a Spatial Boundaries Test from Firestore
     Test._recreateTestConstructors[collectionIDStatic] = (testDoc) {
@@ -1221,6 +1248,7 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
       creationTime: doc['creationTime'],
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
+      testDuration: doc['testDuration'],
     );
   }
 
@@ -1235,6 +1263,7 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
       'creationTime': creationTime,
       'maxResearchers': maxResearchers,
       'isComplete': isComplete,
+      'testDuration': testDuration,
     };
   }
 }
@@ -1302,6 +1331,7 @@ class SectionCutterTest extends Test<Section> with JsonToString {
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         SectionCutterTest._(
           title: title,
@@ -1614,6 +1644,7 @@ class IdentifyingAccessTest extends Test<AccessData> {
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         IdentifyingAccessTest._(
           title: title,
@@ -2102,6 +2133,9 @@ class NaturePrevalenceTest extends Test<NatureData> {
   /// Static constant definition of collection ID for this test type.
   static const String collectionIDStatic = 'nature_prevalence_tests';
 
+  /// User defined test timer duration in seconds.
+  final int testDuration;
+
   /// Creates a new [NaturePrevalenceTest] instance from the given arguments.
   NaturePrevalenceTest._({
     required super.title,
@@ -2113,6 +2147,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
+    required this.testDuration,
   }) : super._();
 
   /// Registers this class within the Maps required by class [Test].
@@ -2125,6 +2160,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         NaturePrevalenceTest._(
           title: title,
@@ -2133,6 +2169,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
           projectRef: projectRef,
           collectionID: collectionID,
           data: newInitialDataDeepCopy(),
+          testDuration: testDuration ?? -1,
         );
     // Register for recreating a Nature Prevalence Test from Firestore
     Test._recreateTestConstructors[collectionIDStatic] = (testDoc) {
@@ -2146,6 +2183,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
         creationTime: testDoc['creationTime'],
         maxResearchers: testDoc['maxResearchers'],
         isComplete: testDoc['isComplete'],
+        testDuration: testDoc['testDuration'],
       );
     };
     // Register for building a Nature Prevalence Test page
@@ -2165,6 +2203,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
         'creationTime': test.creationTime,
         'maxResearchers': test.maxResearchers,
         'isComplete': false,
+        'testDuration': (test as NaturePrevalenceTest).testDuration,
       }, SetOptions(merge: true));
     };
     Test._timerTestCollectionIDs.add(collectionIDStatic);
@@ -2326,9 +2365,11 @@ class NaturePrevalenceTest extends Test<NatureData> {
       output.animals = animalList;
       output.vegetation = vegetationList;
       output.waterBodies = waterBodyList;
-      if (weatherData == null) {
+      if (data.containsKey('data') &&
+          data['data'].containsKey('weather') &&
+          weatherData == null) {
         throw Exception(
-            "Weather is not defined in Firestore in Nature Prevalence test .");
+            "Weather is not defined in Firestore in Nature Prevalence test.");
       } else {
         output.weather = weatherData;
       }
@@ -2539,6 +2580,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
   static const String collectionIDStatic = 'people_in_place_tests';
 
   final List<StandingPoint> standingPoints;
+  final int testDuration;
 
   PeopleInPlaceTest._({
     required super.title,
@@ -2551,6 +2593,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
+    required this.testDuration,
   }) : super._();
 
   static void register() {
@@ -2561,6 +2604,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         PeopleInPlaceTest._(
           title: title,
@@ -2570,6 +2614,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
           collectionID: collectionID,
           data: PeopleInPlaceData(),
           standingPoints: (standingPoints as List<StandingPoint>?) ?? [],
+          testDuration: testDuration ?? -1,
         );
     Test._recreateTestConstructors[collectionIDStatic] = (testDoc) {
       return PeopleInPlaceTest.fromJson(testDoc.data()!);
@@ -2623,6 +2668,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
       standingPoints: StandingPoint.fromJsonList(doc['standingPoints']),
+      testDuration: doc['testDuration'],
     );
   }
 
@@ -2638,6 +2684,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
       'maxResearchers': maxResearchers,
       'isComplete': isComplete,
       'standingPoints': StandingPoint.toJsonList(standingPoints),
+      'testDuration': testDuration,
     };
   }
 }
@@ -2736,6 +2783,9 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
 
   final List<StandingPoint> standingPoints;
 
+  /// User defined test timer duration in seconds.
+  final int testDuration;
+
   /// Private constructor for PeopleInMotionTest.
   PeopleInMotionTest._({
     required super.title,
@@ -2745,6 +2795,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
     required super.collectionID,
     required super.data,
     required this.standingPoints,
+    required this.testDuration,
     super.creationTime,
     super.maxResearchers,
     super.isComplete,
@@ -2760,6 +2811,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
       required DocumentReference projectRef,
       required String collectionID,
       List? standingPoints,
+      int? testDuration,
     }) =>
         PeopleInMotionTest._(
           title: title,
@@ -2769,6 +2821,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
           collectionID: collectionID,
           data: PeopleInMotionData(),
           standingPoints: (standingPoints as List<StandingPoint>?) ?? [],
+          testDuration: testDuration ?? -1,
         );
     // Register for recreating from Firestore
     Test._recreateTestConstructors[collectionIDStatic] = (testDoc) {
@@ -2827,6 +2880,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
       standingPoints: StandingPoint.fromJsonList(doc['standingPoints']),
+      testDuration: doc['testDuration'],
     );
   }
 
@@ -2842,6 +2896,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
       'maxResearchers': maxResearchers,
       'isComplete': isComplete,
       'standingPoints': StandingPoint.toJsonList(standingPoints),
+      'testDuration': testDuration,
     };
   }
 }

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -545,6 +545,7 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
           );
       await testRef.set(test as LightingProfileTest, SetOptions(merge: true));
     };
+    Test._timerTestCollectionIDs.add(collectionIDStatic);
   }
 
   @override
@@ -577,7 +578,8 @@ class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
       creationTime: doc['creationTime'],
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
-      testDuration: doc['testDuration'],
+      testDuration:
+          doc.containsKey('testDuration') ? doc['testDuration'] ?? -1 : -1,
     );
   }
 
@@ -895,6 +897,7 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
           );
       await testRef.set(test as AbsenceOfOrderTest, SetOptions(merge: true));
     };
+    Test._timerTestCollectionIDs.add(collectionIDStatic);
   }
 
   @override
@@ -932,7 +935,8 @@ class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
       creationTime: doc['creationTime'],
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
-      testDuration: doc['testDuration'],
+      testDuration:
+          doc.containsKey('testDuration') ? doc['testDuration'] ?? -1 : -1,
     );
   }
 
@@ -1248,7 +1252,8 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
       creationTime: doc['creationTime'],
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
-      testDuration: doc['testDuration'],
+      testDuration:
+          doc.containsKey('testDuration') ? doc['testDuration'] ?? -1 : -1,
     );
   }
 
@@ -2183,7 +2188,10 @@ class NaturePrevalenceTest extends Test<NatureData> {
         creationTime: testDoc['creationTime'],
         maxResearchers: testDoc['maxResearchers'],
         isComplete: testDoc['isComplete'],
-        testDuration: testDoc['testDuration'],
+        // TODO: delete after database purged. Temporary for existing tests.
+        testDuration: testDoc.data()!.containsKey('testDuration')
+            ? (testDoc['testDuration'] ?? -1)
+            : -1,
       );
     };
     // Register for building a Nature Prevalence Test page
@@ -2636,6 +2644,7 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
       await testRef.set(test as PeopleInPlaceTest, SetOptions(merge: true));
     };
     Test._standingPointTestCollectionIDs.add(collectionIDStatic);
+    Test._timerTestCollectionIDs.add(collectionIDStatic);
   }
 
   @override
@@ -2668,7 +2677,8 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData> with JsonToString {
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
       standingPoints: StandingPoint.fromJsonList(doc['standingPoints']),
-      testDuration: doc['testDuration'],
+      testDuration:
+          doc.containsKey('testDuration') ? doc['testDuration'] ?? -1 : -1,
     );
   }
 
@@ -2846,6 +2856,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
       await testRef.set(test as PeopleInMotionTest, SetOptions(merge: true));
     };
     Test._standingPointTestCollectionIDs.add(collectionIDStatic);
+    Test._timerTestCollectionIDs.add(collectionIDStatic);
   }
 
   /// Handles data submission to Firestore when the test is completed.
@@ -2880,7 +2891,8 @@ class PeopleInMotionTest extends Test<PeopleInMotionData> with JsonToString {
       maxResearchers: doc['maxResearchers'],
       isComplete: doc['isComplete'],
       standingPoints: StandingPoint.fromJsonList(doc['standingPoints']),
-      testDuration: doc['testDuration'],
+      testDuration:
+          doc.containsKey('testDuration') ? doc['testDuration'] ?? -1 : -1,
     );
   }
 

--- a/lib/firestore_functions.dart
+++ b/lib/firestore_functions.dart
@@ -430,6 +430,7 @@ Future<Test> saveTest({
   required DocumentReference? projectRef,
   required String collectionID,
   List? standingPoints,
+  int? testDuration,
 }) async {
   late Test tempTest;
 
@@ -449,6 +450,7 @@ Future<Test> saveTest({
       projectRef: projectRef,
       collectionID: collectionID,
       standingPoints: standingPoints,
+      testDuration: testDuration,
     );
 
     await tempTest.saveToFirestore();

--- a/lib/google_maps_functions.dart
+++ b/lib/google_maps_functions.dart
@@ -56,8 +56,9 @@ Future<LocationPermission> _checkLocationPermissions() async {
 /// polygon out of those points (makes sure the polygon is logical). Returns
 /// the singular polygon as a Set so it can be used directly on the GoogleMap
 /// widget.
+/// Takes an optional onTap parameter.
 Set<Polygon> finalizePolygon(List<LatLng> polygonPoints,
-    [Color? polygonColor]) {
+    {Color? polygonColor, VoidCallback? onTap, bool? consumeTapEvents}) {
   Set<Polygon> polygon = {};
   List<LatLng> polygonPointsCopy = List.of(polygonPoints);
   try {
@@ -69,6 +70,8 @@ Set<Polygon> finalizePolygon(List<LatLng> polygonPoints,
 
     polygon = {
       Polygon(
+        consumeTapEvents: consumeTapEvents ?? false,
+        onTap: onTap,
         polygonId: PolygonId(polygonId),
         points: sortedPoints,
         strokeColor: polygonColor ?? Colors.blue,

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -324,20 +324,35 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                       ),
                     ),
                     Align(
+                      alignment: Alignment.topCenter,
+                      child: _directionsVisible
+                          ? Padding(
+                              padding:
+                                  const EdgeInsets.only(top: 15.0, right: 15.0),
+                              child: DirectionsText(
+                                  onTap: () {
+                                    setState(() {
+                                      _directionsVisible = !_directionsVisible;
+                                    });
+                                  },
+                                  text: _directions),
+                            )
+                          : SizedBox(),
+                    ),
+                    Align(
                       alignment: Alignment.topRight,
                       child: Padding(
-                        padding: const EdgeInsets.only(top: 20.0, right: 20.0),
+                        padding: const EdgeInsets.only(top: 15.0, right: 15.0),
                         child: Column(
                           spacing: 10,
                           mainAxisAlignment: MainAxisAlignment.start,
                           children: [
-                            DirectionsWidget(
+                            DirectionsButton(
                                 onTap: () {
                                   setState(() {
                                     _directionsVisible = !_directionsVisible;
                                   });
                                 },
-                                text: _directions,
                                 visibility: _directionsVisible),
                             CircularIconMapButton(
                               backgroundColor: Colors.green,

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -34,6 +34,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   bool _oldPolylinesToggle = true;
   int? _currentSpotsOrRoute;
   bool _deleteMode = false;
+  double _timerHeight = 90;
   AccessType? _type;
   String _directions = "Choose a category.";
   final double _bottomSheetHeight = 300;
@@ -319,8 +320,36 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        resizeToAvoidBottomInset: false,
+        extendBodyBehindAppBar: true,
         extendBody: true,
+        appBar: PreferredSize(
+          preferredSize: Size.fromHeight(_timerHeight),
+          child: Container(
+            color: Colors.transparent,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                TextButton(onPressed: () {}, child: Text("Start")),
+                TextButton(onPressed: () {}, child: Text("End")),
+                Padding(
+                  padding: const EdgeInsets.only(right: 20),
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.6),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      "19:00",
+                      style: TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        resizeToAvoidBottomInset: false,
         body: _isLoading
             ? const Center(child: CircularProgressIndicator())
             : Center(
@@ -358,47 +387,47 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                     Align(
                       alignment: Alignment.topRight,
                       child: Padding(
-                        padding: EdgeInsets.only(top: 80, right: 20),
-                        child: CircularIconMapButton(
-                          backgroundColor: Colors.green,
-                          borderColor: Color(0xFF2D6040),
-                          onPressed: _toggleMapType,
-                          icon: const Icon(Icons.map),
+                        padding: const EdgeInsets.all(20.0),
+                        child: Column(
+                          spacing: 10,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: [
+                            DirectionsWidget(
+                                onTap: () {
+                                  setState(() {
+                                    _directionsVisible = !_directionsVisible;
+                                  });
+                                },
+                                text: _directions,
+                                visibility: _directionsVisible),
+                            CircularIconMapButton(
+                              backgroundColor: Colors.green,
+                              borderColor: Color(0xFF2D6040),
+                              onPressed: _toggleMapType,
+                              icon: const Icon(Icons.map),
+                            ),
+                            (!_polygonMode && !_pointMode && !_polylineMode)
+                                ? CircularIconMapButton(
+                                    borderColor: Color(0xFF2D6040),
+                                    onPressed: () {
+                                      setState(() {
+                                        _deleteMode = !_deleteMode;
+                                      });
+                                    },
+                                    backgroundColor:
+                                        _deleteMode ? Colors.blue : Colors.red,
+                                    icon: Icon(
+                                      _deleteMode
+                                          ? Icons.location_on
+                                          : Icons.delete,
+                                      size: 30,
+                                    ),
+                                  )
+                                : SizedBox(),
+                          ],
                         ),
                       ),
                     ),
-                    (!_polygonMode && !_pointMode && !_polylineMode)
-                        ? Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: EdgeInsets.only(top: 140, right: 20),
-                              child: CircularIconMapButton(
-                                borderColor: Color(0xFF2D6040),
-                                onPressed: () {
-                                  setState(() {
-                                    _deleteMode = !_deleteMode;
-                                  });
-                                },
-                                backgroundColor:
-                                    _deleteMode ? Colors.blue : Colors.red,
-                                icon: Icon(
-                                  _deleteMode
-                                      ? Icons.location_on
-                                      : Icons.delete,
-                                  size: 30,
-                                ),
-                              ),
-                            ),
-                          )
-                        : SizedBox(),
-                    DirectionsWidget(
-                        onTap: () {
-                          setState(() {
-                            _directionsVisible = !_directionsVisible;
-                          });
-                        },
-                        text: _directions,
-                        visibility: _directionsVisible),
                     Align(
                       alignment: Alignment.bottomLeft,
                       child: Padding(

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -43,9 +41,6 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   late GoogleMapController mapController;
   LatLng _location = defaultLocation; // Default location
   final AccessData _accessData = AccessData();
-  Timer? _timer;
-  int _remainingSeconds = 5;
-  bool _testIsRunning = false;
 
   Set<Polygon> _projectArea = {};
   Polyline? _currentPolyline;
@@ -67,12 +62,6 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   void initState() {
     super.initState();
     initProjectArea();
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
   }
 
   /// Gets the project polygon, adds it to the current polygon list, and
@@ -286,72 +275,6 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
     }
   }
 
-  void _startTest() {
-    setState(() {
-      _testIsRunning = true;
-      _remainingSeconds = 5;
-    });
-    _timer = Timer.periodic(Duration(seconds: 1), (timer) {
-      setState(() {
-        if (_remainingSeconds <= 0) {
-          _endTest();
-          timer.cancel();
-          showDialog(
-              context: context,
-              builder: (context) {
-                return AlertDialog(
-                  scrollable: true,
-                  title: Center(
-                      child: Text(
-                    "Time's Up!",
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  )),
-                  content: Center(
-                      child: Text(
-                    "Would you like to submit your data?",
-                    style: TextStyle(fontSize: 15),
-                  )),
-                  actions: <Widget>[
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        Flexible(
-                          child: TextButton(
-                            onPressed: () {
-                              setState(() {
-                                _remainingSeconds = 10;
-                              });
-                              Navigator.pop(context);
-                            },
-                            child: Text("No, take me back."),
-                          ),
-                        ),
-                        Flexible(
-                          child: TextButton(
-                            onPressed: () {
-                              Navigator.pop(context);
-                              Navigator.pop(context);
-                            },
-                            child: Text("Yes, submit."),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                );
-              });
-        } else {
-          _remainingSeconds--;
-        }
-      });
-    });
-  }
-
-  void _endTest() {
-    _testIsRunning = false;
-    _timer?.cancel();
-  }
-
   void _toggleMapType() {
     setState(() {
       _currentMapType = (_currentMapType == MapType.normal
@@ -364,57 +287,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        extendBodyBehindAppBar: true,
         extendBody: true,
-        appBar: AppBar(
-          leading: null,
-          automaticallyImplyLeading: false,
-          systemOverlayStyle:
-              SystemUiOverlayStyle(statusBarBrightness: Brightness.light),
-          backgroundColor: Colors.transparent,
-          // Timer on the right
-          actionsPadding: EdgeInsets.only(top: 15),
-          actions: [
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius:
-                      BorderRadius.circular(8), // Rounded rectangle shape.
-                ),
-                backgroundColor: _testIsRunning ? Colors.red : Colors.green,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              ),
-              onPressed: () {
-                if (_testIsRunning) {
-                  _endTest();
-                } else {
-                  _startTest();
-                }
-              },
-              child: Text(
-                _testIsRunning ? 'End' : 'Start',
-                style: const TextStyle(color: Colors.white, fontSize: 16),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(left: 10, right: 20),
-              child: Center(
-                child: Container(
-                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.6),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    formatTime(_remainingSeconds),
-                    style: TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
         resizeToAvoidBottomInset: false,
         body: _isLoading
             ? const Center(child: CircularProgressIndicator())
@@ -453,8 +326,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                     Align(
                       alignment: Alignment.topRight,
                       child: Padding(
-                        padding: const EdgeInsets.only(
-                            top: kToolbarHeight + 20, right: 20.0),
+                        padding: const EdgeInsets.only(top: 20.0, right: 20.0),
                         child: Column(
                           spacing: 10,
                           mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -33,6 +33,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   bool _polylineMode = false;
   bool _oldPolylinesToggle = true;
   int? _currentSpotsOrRoute;
+  bool _deleteMode = false;
   AccessType? _type;
   String _directions = "Choose a category.";
   final double _bottomSheetHeight = 300;
@@ -52,7 +53,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   Set<Polygon> _polygons = {}; // Set of polygons
   final Set<Marker> _markers = {}; // Set of markers for points
   Set<Marker> _polygonMarkers = {}; // Set of markers for polygon creation
-  bool _directionsVisible = true;
+  bool _directionsVisible = false;
   MapType _currentMapType = MapType.satellite; // Default map type
 
   Project? project;
@@ -354,6 +355,42 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                         mapType: _currentMapType, // Use current map type
                       ),
                     ),
+                    Align(
+                      alignment: Alignment.topRight,
+                      child: Padding(
+                        padding: EdgeInsets.only(top: 80, right: 20),
+                        child: CircularIconMapButton(
+                          backgroundColor: Colors.green,
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: const Icon(Icons.map),
+                        ),
+                      ),
+                    ),
+                    (!_polygonMode && !_pointMode && !_polylineMode)
+                        ? Align(
+                            alignment: Alignment.topRight,
+                            child: Padding(
+                              padding: EdgeInsets.only(top: 140, right: 20),
+                              child: CircularIconMapButton(
+                                borderColor: Color(0xFF2D6040),
+                                onPressed: () {
+                                  setState(() {
+                                    _deleteMode = !_deleteMode;
+                                  });
+                                },
+                                backgroundColor:
+                                    _deleteMode ? Colors.blue : Colors.red,
+                                icon: Icon(
+                                  _deleteMode
+                                      ? Icons.location_on
+                                      : Icons.delete,
+                                  size: 30,
+                                ),
+                              ),
+                            ),
+                          )
+                        : SizedBox(),
                     DirectionsWidget(
                         onTap: () {
                           setState(() {
@@ -362,19 +399,6 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                         },
                         text: _directions,
                         visibility: _directionsVisible),
-                    Align(
-                      alignment: Alignment.bottomLeft,
-                      child: Padding(
-                        padding: EdgeInsets.only(
-                            bottom: _bottomSheetHeight + 130, left: 5),
-                        child: FloatingActionButton(
-                          heroTag: null,
-                          onPressed: _toggleMapType,
-                          backgroundColor: Colors.green,
-                          child: const Icon(Icons.map),
-                        ),
-                      ),
-                    ),
                     Align(
                       alignment: Alignment.bottomLeft,
                       child: Padding(
@@ -396,245 +420,272 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
               ),
         bottomSheet: _isLoading
             ? SizedBox()
-            : Container(
+            : SizedBox(
                 height: _bottomSheetHeight,
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 12.0, vertical: 10.0),
-                decoration: BoxDecoration(
-                  gradient: defaultGrad,
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(24.0),
-                    topRight: Radius.circular(24.0),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black,
-                      offset: Offset(0.0, 1.0), //(x,y)
-                      blurRadius: 6.0,
-                    ),
-                  ],
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                child: Stack(
                   children: [
-                    SizedBox(height: 5),
-                    Center(
-                      child: Text(
-                        'Identifying Access',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: placeYellow,
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12.0, vertical: 10.0),
+                      decoration: BoxDecoration(
+                        gradient: defaultGrad,
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(24.0),
+                          topRight: Radius.circular(24.0),
                         ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black,
+                            offset: Offset(0.0, 1.0), //(x,y)
+                            blurRadius: 6.0,
+                          ),
+                        ],
                       ),
-                    ),
-                    Align(
-                      alignment: Alignment.topCenter,
-                      child: Text(
-                        'Mark where people enter the project area from.',
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontStyle: FontStyle.italic,
-                          color: Colors.grey[400],
-                        ),
-                      ),
-                    ),
-                    SizedBox(height: 15),
-                    Center(
-                      child: Text(
-                        'Access Type',
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                    ),
-                    SizedBox(height: 5),
-                    Row(
-                      spacing: 10,
-                      children: <Widget>[
-                        TestButton(
-                          flex: 6,
-                          buttonText: 'Parking',
-                          onPressed:
-                              (_pointMode || _polygonMode || _polylineMode)
-                                  ? null
-                                  : () {
-                                      setState(() {
-                                        _type = AccessType.parking;
-                                        _polygonMode = true;
-                                        _directions =
-                                            'First, define the parking area by creating a polygon.';
-                                      });
-                                    },
-                        ),
-                        TestButton(
-                          flex: 6,
-                          buttonText: 'Public Transport',
-                          onPressed:
-                              (_pointMode || _polygonMode || _polylineMode)
-                                  ? null
-                                  : () {
-                                      _showDialog(
-                                        text: 'Enter the Route Number',
-                                        hintText: 'Route Number',
-                                        onNext: () {
-                                          setState(() {
-                                            _type = AccessType.transportStation;
-                                            _polylineMode = true;
-                                            _directions =
-                                                "Mark the spot of the transport station. Then define the path to the project area.";
-                                          });
-                                        },
-                                      );
-                                    },
-                        ),
-                      ],
-                    ),
-                    Row(
-                      spacing: 10,
-                      children: <Widget>[
-                        TestButton(
-                          flex: 6,
-                          onPressed: (_pointMode ||
-                                  _polygonMode ||
-                                  _polylineMode)
-                              ? null
-                              : () {
-                                  _showDialog(
-                                    text: 'How Many Bikes/Scooters Can Fit?',
-                                    hintText: 'Enter number of spots.',
-                                    onNext: () {
-                                      setState(() {
-                                        _type = AccessType.bikeRack;
-                                        _polylineMode = true;
-                                        _directions =
-                                            "Mark the spot of the bike/scooter rack. Then define the path to the project area.";
-                                      });
-                                    },
-                                  );
-                                },
-                          buttonText: 'Bike or Scooter Rack',
-                        ),
-                        TestButton(
-                          flex: 6,
-                          buttonText: 'Taxi or Rideshare',
-                          onPressed:
-                              (_pointMode || _polygonMode || _polylineMode)
-                                  ? null
-                                  : () {
-                                      setState(() {
-                                        _type = AccessType.taxiAndRideShare;
-                                        _polylineMode = true;
-                                        _directions =
-                                            'Mark a point where the taxi dropped off. Then make a line to denote the path to the project area.';
-                                      });
-                                    },
-                        ),
-                      ],
-                    ),
-                    SizedBox(height: 20),
-                    Expanded(
-                      child: Row(
-                        spacing: 10,
-                        children: <Widget>[
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(height: 5),
+                          Center(
+                            child: Text(
+                              'Identifying Access',
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                                color: placeYellow,
+                              ),
+                            ),
+                          ),
+                          Align(
+                            alignment: Alignment.topCenter,
+                            child: Text(
+                              'Mark where people enter the project area from.',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontStyle: FontStyle.italic,
+                                color: Colors.grey[400],
+                              ),
+                            ),
+                          ),
+                          SizedBox(height: 15),
+                          Center(
+                            child: Text(
+                              'Access Type',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                          SizedBox(height: 5),
+                          Row(
+                            spacing: 10,
+                            children: <Widget>[
+                              TestButton(
+                                flex: 6,
+                                buttonText: 'Parking',
+                                onPressed: (_pointMode ||
+                                        _polygonMode ||
+                                        _polylineMode ||
+                                        _deleteMode)
+                                    ? null
+                                    : () {
+                                        setState(() {
+                                          _type = AccessType.parking;
+                                          _polygonMode = true;
+                                          _directions =
+                                              'First, define the parking area by creating a polygon.';
+                                        });
+                                      },
+                              ),
+                              TestButton(
+                                flex: 6,
+                                buttonText: 'Public Transport',
+                                onPressed: (_pointMode ||
+                                        _polygonMode ||
+                                        _polylineMode ||
+                                        _deleteMode)
+                                    ? null
+                                    : () {
+                                        _showDialog(
+                                          text: 'Enter the Route Number',
+                                          hintText: 'Route Number',
+                                          onNext: () {
+                                            setState(() {
+                                              _type =
+                                                  AccessType.transportStation;
+                                              _polylineMode = true;
+                                              _directions =
+                                                  "Mark the spot of the transport station. Then define the path to the project area.";
+                                            });
+                                          },
+                                        );
+                                      },
+                              ),
+                            ],
+                          ),
+                          Row(
+                            spacing: 10,
+                            children: <Widget>[
+                              TestButton(
+                                flex: 6,
+                                onPressed: (_pointMode ||
+                                        _polygonMode ||
+                                        _polylineMode ||
+                                        _deleteMode)
+                                    ? null
+                                    : () {
+                                        _showDialog(
+                                          text:
+                                              'How Many Bikes/Scooters Can Fit?',
+                                          hintText: 'Enter number of spots.',
+                                          onNext: () {
+                                            setState(() {
+                                              _type = AccessType.bikeRack;
+                                              _polylineMode = true;
+                                              _directions =
+                                                  "Mark the spot of the bike/scooter rack. Then define the path to the project area.";
+                                            });
+                                          },
+                                        );
+                                      },
+                                buttonText: 'Bike or Scooter Rack',
+                              ),
+                              TestButton(
+                                flex: 6,
+                                buttonText: 'Taxi or Rideshare',
+                                onPressed: (_pointMode ||
+                                        _polygonMode ||
+                                        _polylineMode ||
+                                        _deleteMode)
+                                    ? null
+                                    : () {
+                                        setState(() {
+                                          _type = AccessType.taxiAndRideShare;
+                                          _polylineMode = true;
+                                          _directions =
+                                              'Mark a point where the taxi dropped off. Then make a line to denote the path to the project area.';
+                                        });
+                                      },
+                              ),
+                            ],
+                          ),
+                          SizedBox(height: 20),
                           Expanded(
                             child: Row(
                               spacing: 10,
                               children: <Widget>[
-                                Flexible(
-                                  child: EditButton(
-                                    text: 'Confirm Shape',
-                                    foregroundColor: Colors.green,
-                                    backgroundColor: Colors.white,
-                                    icon: const Icon(Icons.check),
-                                    iconColor: Colors.green,
-                                    onPressed: ((_polylineMode &&
-                                                (_currentPolyline != null &&
-                                                    _currentPolyline!
-                                                            .points.length >
-                                                        2)) ||
-                                            (_polygonMode &&
-                                                _polygonPoints.length >= 3))
-                                        ? _finalizeShape
-                                        : null,
+                                Expanded(
+                                  child: Row(
+                                    spacing: 10,
+                                    children: <Widget>[
+                                      Flexible(
+                                        child: EditButton(
+                                          text: 'Confirm Shape',
+                                          foregroundColor: Colors.green,
+                                          backgroundColor: Colors.white,
+                                          icon: const Icon(Icons.check),
+                                          iconColor: Colors.green,
+                                          onPressed: ((_polylineMode &&
+                                                      (_currentPolyline !=
+                                                              null &&
+                                                          _currentPolyline!
+                                                                  .points
+                                                                  .length >
+                                                              2)) ||
+                                                  (_polygonMode &&
+                                                      _polygonPoints.length >=
+                                                          3))
+                                              ? _finalizeShape
+                                              : null,
+                                        ),
+                                      ),
+                                      Flexible(
+                                        child: EditButton(
+                                          text: 'Cancel',
+                                          foregroundColor: Colors.red,
+                                          backgroundColor: Colors.white,
+                                          icon: const Icon(Icons.cancel),
+                                          iconColor: Colors.red,
+                                          onPressed: (_polylineMode ||
+                                                  _polygonMode)
+                                              ? () {
+                                                  setState(() {
+                                                    _pointMode = false;
+                                                    _polygonMode = false;
+                                                    _polylineMode = false;
+                                                    _polylineMarkers = {};
+                                                    _currentPolyline = null;
+                                                    _currentPolylinePoints = [];
+                                                    _visiblePolylineMarkers =
+                                                        {};
+                                                    _polygonMarkers = {};
+                                                    _currentPolygon = {};
+                                                    _directions =
+                                                        'Choose a category. Or, click finish if done.';
+                                                  });
+                                                  _polygonPoints = [];
+                                                }
+                                              : null,
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 ),
                                 Flexible(
-                                  child: EditButton(
-                                    text: 'Cancel',
-                                    foregroundColor: Colors.red,
-                                    backgroundColor: Colors.white,
-                                    icon: const Icon(Icons.cancel),
-                                    iconColor: Colors.red,
-                                    onPressed: (_polylineMode || _polygonMode)
-                                        ? () {
-                                            setState(() {
-                                              _pointMode = false;
-                                              _polygonMode = false;
-                                              _polylineMode = false;
-                                              _polylineMarkers = {};
-                                              _currentPolyline = null;
-                                              _currentPolylinePoints = [];
-                                              _visiblePolylineMarkers = {};
-                                              _polygonMarkers = {};
-                                              _currentPolygon = {};
-                                              _directions =
-                                                  'Choose a category. Or, click finish if done.';
-                                            });
-                                            _polygonPoints = [];
-                                          }
-                                        : null,
+                                  flex: 0,
+                                  child: Align(
+                                    alignment: Alignment.centerRight,
+                                    child: EditButton(
+                                      text: 'Finish',
+                                      foregroundColor: Colors.black,
+                                      backgroundColor: Colors.white,
+                                      icon: const Icon(Icons.chevron_right,
+                                          color: Colors.black),
+                                      onPressed: (_polygonMode ||
+                                              _polylineMode ||
+                                              _deleteMode)
+                                          ? null
+                                          : () {
+                                              showDialog(
+                                                  context: context,
+                                                  builder: (context) {
+                                                    return TestFinishDialog(
+                                                      onNext: () {
+                                                        widget.activeTest
+                                                            .submitData(
+                                                                _accessData);
+                                                        Navigator.pushReplacement(
+                                                            context,
+                                                            MaterialPageRoute(
+                                                              builder: (context) =>
+                                                                  HomeScreen(),
+                                                            ));
+                                                        Navigator.push(
+                                                            context,
+                                                            MaterialPageRoute(
+                                                              builder: (context) =>
+                                                                  ProjectDetailsPage(
+                                                                      projectData:
+                                                                          widget
+                                                                              .activeProject),
+                                                            ));
+                                                      },
+                                                    );
+                                                  });
+                                            },
+                                    ),
                                   ),
                                 ),
                               ],
                             ),
-                          ),
-                          Flexible(
-                            flex: 0,
-                            child: Align(
-                              alignment: Alignment.centerRight,
-                              child: EditButton(
-                                text: 'Finish',
-                                foregroundColor: Colors.black,
-                                backgroundColor: Colors.white,
-                                icon: const Icon(Icons.chevron_right,
-                                    color: Colors.black),
-                                onPressed: (_polygonMode || _polylineMode)
-                                    ? null
-                                    : () {
-                                        showDialog(
-                                            context: context,
-                                            builder: (context) {
-                                              return TestFinishDialog(
-                                                onNext: () {
-                                                  widget.activeTest
-                                                      .submitData(_accessData);
-                                                  Navigator.pushReplacement(
-                                                      context,
-                                                      MaterialPageRoute(
-                                                        builder: (context) =>
-                                                            HomeScreen(),
-                                                      ));
-                                                  Navigator.push(
-                                                      context,
-                                                      MaterialPageRoute(
-                                                        builder: (context) =>
-                                                            ProjectDetailsPage(
-                                                                projectData: widget
-                                                                    .activeProject),
-                                                      ));
-                                                },
-                                              );
-                                            });
-                                      },
-                              ),
-                            ),
-                          ),
+                          )
                         ],
                       ),
-                    )
+                    ),
+                    _deleteMode
+                        ? TestErrorText(text: "You are in delete mode.")
+                        : SizedBox(),
                   ],
                 ),
               ),

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -724,6 +724,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                 _animalData.removeWhere((animal) => animal.point == point);
                 setState(() {
                   _markers.removeWhere((marker) => marker.markerId == markerId);
+                  _deleteMode = false;
                 });
               }
             },
@@ -816,14 +817,14 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                         mapType: _currentMapType, // Use current map type
                       ),
                     ),
-                    Align(
-                      alignment: Alignment.topRight,
-                      child: Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Column(
-                          spacing: 10,
-                          children: [
-                            DirectionsWidget(
+                    Padding(
+                      padding: const EdgeInsets.all(20.0),
+                      child: Column(
+                        spacing: 10,
+                        children: [
+                          Align(
+                            alignment: Alignment.topRight,
+                            child: DirectionsWidget(
                                 onTap: () {
                                   setState(() {
                                     _directionsVisible = !_directionsVisible;
@@ -831,14 +832,20 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                 },
                                 text: _directions,
                                 visibility: _directionsVisible),
-                            CircularIconMapButton(
+                          ),
+                          Align(
+                            alignment: Alignment.topRight,
+                            child: CircularIconMapButton(
                               backgroundColor: Colors.green,
                               borderColor: Color(0xFF2D6040),
                               onPressed: _toggleMapType,
                               icon: const Icon(Icons.map),
                             ),
-                            (!_polygonMode && !_pointMode)
-                                ? CircularIconMapButton(
+                          ),
+                          (!_polygonMode && !_pointMode)
+                              ? Align(
+                                  alignment: Alignment.topRight,
+                                  child: CircularIconMapButton(
                                     borderColor: Color(0xFF2D6040),
                                     onPressed: () {
                                       setState(() {
@@ -862,10 +869,10 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                           : Icons.delete,
                                       size: 30,
                                     ),
-                                  )
-                                : SizedBox(),
-                          ],
-                        ),
+                                  ),
+                                )
+                              : SizedBox(),
+                        ],
                       ),
                     ),
                     Align(

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -819,55 +819,55 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                     Align(
                       alignment: Alignment.topRight,
                       child: Padding(
-                        padding: EdgeInsets.only(top: 80, right: 20),
-                        child: CircularIconMapButton(
-                          backgroundColor: Colors.green,
-                          borderColor: Color(0xFF2D6040),
-                          onPressed: _toggleMapType,
-                          icon: const Icon(Icons.map),
+                        padding: const EdgeInsets.all(20.0),
+                        child: Column(
+                          spacing: 10,
+                          children: [
+                            DirectionsWidget(
+                                onTap: () {
+                                  setState(() {
+                                    _directionsVisible = !_directionsVisible;
+                                  });
+                                },
+                                text: _directions,
+                                visibility: _directionsVisible),
+                            CircularIconMapButton(
+                              backgroundColor: Colors.green,
+                              borderColor: Color(0xFF2D6040),
+                              onPressed: _toggleMapType,
+                              icon: const Icon(Icons.map),
+                            ),
+                            (!_polygonMode && !_pointMode)
+                                ? CircularIconMapButton(
+                                    borderColor: Color(0xFF2D6040),
+                                    onPressed: () {
+                                      setState(() {
+                                        _deleteMode = !_deleteMode;
+                                        if (_deleteMode == true) {
+                                          _outsidePoint = false;
+                                          _errorText =
+                                              'You are in delete mode.';
+                                        } else {
+                                          _outsidePoint = false;
+                                          _errorText =
+                                              'You tried to place a point outside of the project area!';
+                                        }
+                                      });
+                                    },
+                                    backgroundColor:
+                                        _deleteMode ? Colors.blue : Colors.red,
+                                    icon: Icon(
+                                      _deleteMode
+                                          ? Icons.location_on
+                                          : Icons.delete,
+                                      size: 30,
+                                    ),
+                                  )
+                                : SizedBox(),
+                          ],
                         ),
                       ),
                     ),
-                    (!_polygonMode && !_pointMode)
-                        ? Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: EdgeInsets.only(top: 140, right: 20),
-                              child: CircularIconMapButton(
-                                borderColor: Color(0xFF2D6040),
-                                onPressed: () {
-                                  setState(() {
-                                    _deleteMode = !_deleteMode;
-                                    if (_deleteMode == true) {
-                                      _outsidePoint = false;
-                                      _errorText = 'You are in delete mode.';
-                                    } else {
-                                      _outsidePoint = false;
-                                      _errorText =
-                                          'You tried to place a point outside of the project area!';
-                                    }
-                                  });
-                                },
-                                backgroundColor:
-                                    _deleteMode ? Colors.blue : Colors.red,
-                                icon: Icon(
-                                  _deleteMode
-                                      ? Icons.location_on
-                                      : Icons.delete,
-                                  size: 30,
-                                ),
-                              ),
-                            ),
-                          )
-                        : SizedBox(),
-                    DirectionsWidget(
-                        onTap: () {
-                          setState(() {
-                            _directionsVisible = !_directionsVisible;
-                          });
-                        },
-                        text: _directions,
-                        visibility: _directionsVisible),
                     Align(
                       alignment: Alignment.bottomLeft,
                       child: Padding(

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -80,12 +80,6 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
     });
   }
 
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
   void _startTest() {
     setState(() {
       _testIsRunning = true;
@@ -1078,7 +1072,8 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                               DisplayModalButton(
                                   onPressed: (_pointMode ||
                                           _polygonMode ||
-                                          _deleteMode)
+                                          _deleteMode ||
+                                          !_testIsRunning)
                                       ? null
                                       : () {
                                           showModalAnimal(context);
@@ -1088,7 +1083,8 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                               DisplayModalButton(
                                   onPressed: (_pointMode ||
                                           _polygonMode ||
-                                          _deleteMode)
+                                          _deleteMode ||
+                                          !_testIsRunning)
                                       ? null
                                       : () {
                                           showModalVegetation(context);
@@ -1116,7 +1112,8 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                               DisplayModalButton(
                                   onPressed: (_pointMode ||
                                           _polygonMode ||
-                                          _deleteMode)
+                                          _deleteMode ||
+                                          !_testIsRunning)
                                       ? null
                                       : () {
                                           showModalWaterBody(context);

--- a/lib/project_details_page.dart
+++ b/lib/project_details_page.dart
@@ -313,6 +313,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
       standingPoints: newTestInfo.containsKey('standingPoints')
           ? newTestInfo['standingPoints']
           : null,
+      testDuration: newTestInfo.containsKey('testDuration')
+          ? newTestInfo['testDuration']
+          : null,
     );
     setState(() {
       widget.projectData.tests?.add(test);

--- a/lib/project_details_page.dart
+++ b/lib/project_details_page.dart
@@ -455,7 +455,7 @@ class TestCard extends StatelessWidget {
                       tooltip: 'Start test',
                       onPressed: () async {
                         if (test.isComplete) {
-                          final bool doOverwrite = await showDialog(
+                          final bool? doOverwrite = await showDialog(
                             context: context,
                             builder: (context) {
                               return RedoConfirmationWidget(
@@ -464,7 +464,9 @@ class TestCard extends StatelessWidget {
                               );
                             },
                           );
-                          if (doOverwrite && context.mounted) {
+                          if (doOverwrite != null &&
+                              doOverwrite &&
+                              context.mounted) {
                             Navigator.push(
                               context,
                               MaterialPageRoute(

--- a/lib/project_map_creation.dart
+++ b/lib/project_map_creation.dart
@@ -130,6 +130,7 @@ class _ProjectMapCreationState extends State<ProjectMapCreation> {
                 _markers.removeWhere((marker) => marker.markerId == markerId);
                 _standingPoints.removeWhere(
                     (standingPoint) => standingPoint.location == point);
+                _deleteMode = false;
               });
             }
           },

--- a/lib/section_creation_page.dart
+++ b/lib/section_creation_page.dart
@@ -91,6 +91,10 @@ class _SectionCreationPageState extends State<SectionCreationPage> {
             setState(() {
               _linePoints.remove(point);
               _markers.removeWhere((marker) => marker.markerId == markerId);
+              final Polyline? polyline =
+                  createPolyline(_linePoints, Colors.green[600]!);
+              if (polyline == null) return;
+              _polyline = polyline;
             });
           },
         ),

--- a/lib/section_creation_page.dart
+++ b/lib/section_creation_page.dart
@@ -159,14 +159,22 @@ class _SectionCreationPageState extends State<SectionCreationPage> {
                           mapType: _currentMapType, // Use current map type
                           onTap: _polylineTap,
                         ),
-                        DirectionsWidget(
-                          onTap: () {
-                            setState(() {
-                              _directionsVisible = !_directionsVisible;
-                            });
-                          },
-                          text: _directions,
-                          visibility: _directionsVisible,
+                        Row(
+                          children: [
+                            Center(
+                                child: DirectionsText(
+                              onTap: () {},
+                              text: _directions,
+                            )),
+                            DirectionsButton(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
+                              visibility: _directionsVisible,
+                            ),
+                          ],
                         ),
                         Align(
                           alignment: Alignment.bottomLeft,

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -46,7 +46,7 @@ class _SectionCutterState extends State<SectionCutter> {
   Set<Polygon> _polygons = {}; // Set of polygons
   Set<Polyline> _polyline = {};
   List<LatLng> _sectionPoints = [];
-  bool _directionsVisible = true;
+  bool _directionsVisible = false;
 
   MapType _currentMapType = MapType.satellite; // Default map type
 

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -125,13 +125,12 @@ class _SectionCutterState extends State<SectionCutter> {
                   mapType: _currentMapType, // Use current map type
                 ),
               ),
-              DirectionsWidget(
+              DirectionsButton(
                   onTap: () {
                     setState(() {
                       _directionsVisible = !_directionsVisible;
                     });
                   },
-                  text: _directions,
                   visibility: _directionsVisible),
               Align(
                 alignment: Alignment.bottomLeft,

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -300,6 +300,7 @@ class DialogTextBox extends StatelessWidget {
   final Icon? icon;
   final String? errorMessage;
   final int? minChars;
+  final TextAlign? textAlign;
 
   const DialogTextBox({
     super.key,
@@ -312,6 +313,7 @@ class DialogTextBox extends StatelessWidget {
     this.keyboardType,
     this.inputFormatter,
     this.autofocus,
+    this.textAlign,
   });
   @override
   Widget build(BuildContext context) {
@@ -322,6 +324,7 @@ class DialogTextBox extends StatelessWidget {
               selectionColor: Colors.blue, selectionHandleColor: Colors.blue),
         ),
         child: TextFormField(
+          textAlign: textAlign ?? TextAlign.left,
           onChanged: onChanged,
           keyboardType: keyboardType,
           inputFormatters: inputFormatter,
@@ -645,22 +648,26 @@ class TestFinishDialog extends StatelessWidget {
   }
 }
 
-/// Directions widget used for tests.
-///
-/// Pass through a [visibility] variable. This should be of type [bool] and
-/// control the visibility of the directions. The [onTap] function passed
-/// should toggle the [visibility] boolean in a [setState]. It may do other
-/// things on top of this if desired. The [text] should be the directions
-/// variable which controls the text to display.
 class DirectionsWidget extends StatelessWidget {
+  /// Directions widget used for tests.
+  ///
+  /// Pass through a [visibility] variable. This should be of type [bool] and
+  /// control the visibility of the directions. The [onTap] function passed
+  /// should toggle the [visibility] boolean in a [setState]. It may do other
+  /// things on top of this if desired. The [text] should be the directions
+  /// variable which controls the text to display.
+  ///
+  /// Default button padding of 20.
   const DirectionsWidget({
     super.key,
     required this.onTap,
     required this.text,
     required this.visibility,
+    this.buttonPadding,
   });
 
   final VoidCallback? onTap;
+  final EdgeInsets? buttonPadding;
   final String text;
   final bool visibility;
 
@@ -704,7 +711,7 @@ class DirectionsWidget extends StatelessWidget {
         : Align(
             alignment: Alignment.topRight,
             child: Padding(
-              padding: const EdgeInsets.all(20.0),
+              padding: buttonPadding ?? const EdgeInsets.all(20.0),
               child: Container(
                 decoration: BoxDecoration(
                     borderRadius: const BorderRadius.all(Radius.circular(50)),

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -641,8 +641,8 @@ class TestFinishDialog extends StatelessWidget {
             onPressed: () {
               Navigator.pop(context);
             },
-            child: Text("Cancel")),
-        TextButton(onPressed: onNext, child: Text("Next"))
+            child: Text("No, take me back.")),
+        TextButton(onPressed: onNext, child: Text("Yes, finish."))
       ],
     );
   }
@@ -673,38 +673,35 @@ class DirectionsWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return visibility
-        ? Align(
-            alignment: Alignment.topCenter,
-            child: Padding(
-              padding:
-                  const EdgeInsets.symmetric(vertical: 20.0, horizontal: 25.0),
-              child: InkWell(
-                onTap: onTap,
-                child: Container(
-                    padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-                    decoration: BoxDecoration(
-                      color: directionsTransparency,
-                      gradient: defaultGrad,
-                      borderRadius: const BorderRadius.all(Radius.circular(10)),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.1),
-                          blurRadius: 6,
-                          offset: const Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Text(
-                      text,
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w500,
-                        color: Colors.white,
+        ? Padding(
+            padding:
+                const EdgeInsets.symmetric(vertical: 20.0, horizontal: 25.0),
+            child: InkWell(
+              onTap: onTap,
+              child: Container(
+                  padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: directionsTransparency,
+                    gradient: defaultGrad,
+                    borderRadius: const BorderRadius.all(Radius.circular(10)),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.1),
+                        blurRadius: 6,
+                        offset: const Offset(0, 2),
                       ),
-                    )),
-              ),
+                    ],
+                  ),
+                  child: Text(
+                    text,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.white,
+                    ),
+                  )),
             ),
           )
         : Container(

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -656,8 +656,7 @@ class DirectionsWidget extends StatelessWidget {
   /// should toggle the [visibility] boolean in a [setState]. It may do other
   /// things on top of this if desired. The [text] should be the directions
   /// variable which controls the text to display.
-  ///
-  /// Default button padding of 20.
+  /// Should be placed in a Column w/ other widgets (delete mode, map type)
   const DirectionsWidget({
     super.key,
     required this.onTap,
@@ -708,31 +707,25 @@ class DirectionsWidget extends StatelessWidget {
               ),
             ),
           )
-        : Align(
-            alignment: Alignment.topRight,
-            child: Padding(
-              padding: buttonPadding ?? const EdgeInsets.all(20.0),
-              child: Container(
-                decoration: BoxDecoration(
-                    borderRadius: const BorderRadius.all(Radius.circular(50)),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.1),
-                        blurRadius: 6,
-                        offset: const Offset(0, 2),
-                      ),
-                    ],
-                    gradient: defaultGrad,
-                    color: directionsTransparency),
-                child: IconButton(
-                    color: Colors.white,
-                    onPressed: onTap,
-                    icon: Icon(
-                      Icons.help_outline,
-                      size: 35,
-                    )),
-              ),
-            ),
+        : Container(
+            decoration: BoxDecoration(
+                borderRadius: const BorderRadius.all(Radius.circular(50)),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.1),
+                    blurRadius: 6,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+                gradient: defaultGrad,
+                color: directionsTransparency),
+            child: IconButton(
+                color: Colors.white,
+                onPressed: onTap,
+                icon: Icon(
+                  Icons.help_outline,
+                  size: 35,
+                )),
           );
   }
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -380,6 +380,54 @@ class DialogTextBox extends StatelessWidget {
   }
 }
 
+class TimeFormField extends StatelessWidget {
+  const TimeFormField({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      decoration: InputDecoration(
+        alignLabelWithHint: true,
+        counterStyle: const TextStyle(color: Colors.black),
+        errorBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(10)),
+          borderSide: BorderSide(
+            color: Color(0xFFD32F2F),
+            width: 1.5,
+          ),
+        ),
+        focusedErrorBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(10)),
+          borderSide: BorderSide(
+            color: Color(0xFFD32F2F),
+            width: 2,
+          ),
+        ),
+        enabledBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(10)),
+          borderSide: BorderSide(
+            width: 1.5,
+            color: Color(0xFF6A89B8),
+          ),
+        ),
+        focusedBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(10)),
+          borderSide: BorderSide(
+            width: 2,
+            color: Color(0xFF5C78A1),
+          ),
+        ),
+        hintText: "A",
+        label: Text("Hour"),
+        hintStyle: const TextStyle(
+          fontWeight: FontWeight.w300,
+          color: Color(0xA9000000),
+        ),
+      ),
+    );
+  }
+}
+
 /// Circular button used on top of `GoogleMap` widget.
 class CircularIconMapButton extends StatelessWidget {
   final Color backgroundColor;

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
 
+import 'google_maps_functions.dart';
+
 /// Bar Indicator for the Sliding Up Panels (Edit Project, Results)
 class BarIndicator extends StatelessWidget {
   const BarIndicator({
@@ -284,12 +286,6 @@ class PasswordTextFormField extends StatelessWidget {
   }
 }
 
-/// Text form field used for dialog boxes.
-///
-/// Enter an [errorMessage] for error validation. Put in a form for validation.
-/// Takes a [maxLength], [labelText] and optional [errorMessage], [icon], and
-/// [onChanged]. Optional [minChars] parameter to specify the minimum number of
-/// characters for validation (default: 3)
 class DialogTextBox extends StatelessWidget {
   final int? maxLength;
   final String labelText;
@@ -302,6 +298,12 @@ class DialogTextBox extends StatelessWidget {
   final int? minChars;
   final TextAlign? textAlign;
 
+  /// Text form field used for dialog boxes.
+  ///
+  /// Enter an [errorMessage] for error validation. Put in a form for validation.
+  /// Takes a [maxLength], [labelText] and optional [errorMessage], [icon], and
+  /// [onChanged]. Optional [minChars] parameter to specify the minimum number of
+  /// characters for validation (default: 3)
   const DialogTextBox({
     super.key,
     this.maxLength,
@@ -380,61 +382,99 @@ class DialogTextBox extends StatelessWidget {
   }
 }
 
-class TimeFormField extends StatelessWidget {
-  const TimeFormField({super.key});
+class TimerButtonAndDisplay extends StatelessWidget {
+  const TimerButtonAndDisplay(
+      {required this.onPressed,
+      required this.testIsRunning,
+      required this.remainingSeconds,
+      super.key});
+
+  final VoidCallback onPressed;
+  final bool testIsRunning;
+  final int remainingSeconds;
 
   @override
   Widget build(BuildContext context) {
-    return TextFormField(
-      decoration: InputDecoration(
-        alignLabelWithHint: true,
-        counterStyle: const TextStyle(color: Colors.black),
-        errorBorder: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(10)),
-          borderSide: BorderSide(
-            color: Color(0xFFD32F2F),
-            width: 1.5,
+    return Column(children: <Widget>[
+      ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8), // Rounded rectangle shape.
           ),
+          backgroundColor: testIsRunning ? Colors.red : Colors.green,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         ),
-        focusedErrorBorder: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(10)),
-          borderSide: BorderSide(
-            color: Color(0xFFD32F2F),
-            width: 2,
-          ),
-        ),
-        enabledBorder: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(10)),
-          borderSide: BorderSide(
-            width: 1.5,
-            color: Color(0xFF6A89B8),
-          ),
-        ),
-        focusedBorder: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(10)),
-          borderSide: BorderSide(
-            width: 2,
-            color: Color(0xFF5C78A1),
-          ),
-        ),
-        hintText: "A",
-        label: Text("Hour"),
-        hintStyle: const TextStyle(
-          fontWeight: FontWeight.w300,
-          color: Color(0xA9000000),
+        onPressed: onPressed,
+        child: Text(
+          testIsRunning ? 'End' : 'Start',
+          style: const TextStyle(color: Colors.white, fontSize: 16),
         ),
       ),
+      Container(
+        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.6),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          formatTime(remainingSeconds),
+          style: TextStyle(color: Colors.white, fontSize: 16),
+        ),
+      ),
+    ]);
+  }
+}
+
+class TimerEndDialog extends StatelessWidget {
+  /// Dialog displayed when timer runs out.
+  const TimerEndDialog(
+      {required this.onSubmit, required this.onBack, super.key});
+  final VoidCallback? onSubmit;
+  final VoidCallback? onBack;
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      scrollable: true,
+      title: Center(
+          child: Text(
+        "Time's Up!",
+        style: TextStyle(fontWeight: FontWeight.bold),
+      )),
+      content: Center(
+          child: Text(
+        "Would you like to submit your data?",
+        style: TextStyle(fontSize: 15),
+      )),
+      actions: <Widget>[
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Flexible(
+              child: TextButton(
+                onPressed: onBack,
+                child: Text("No, take me back."),
+              ),
+            ),
+            Flexible(
+              child: TextButton(
+                onPressed: onSubmit,
+                child: Text("Yes, submit."),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }
 
-/// Circular button used on top of `GoogleMap` widget.
 class CircularIconMapButton extends StatelessWidget {
   final Color backgroundColor;
   final Color borderColor;
   final Widget icon;
   final void Function() onPressed;
 
+  /// Circular button used on top of `GoogleMap` widget.
   const CircularIconMapButton({
     super.key,
     required this.backgroundColor,
@@ -466,8 +506,8 @@ class CircularIconMapButton extends StatelessWidget {
   }
 }
 
-/// Warning used when point placed outside project polygon on test.
 class OutsideBoundsWarning extends StatelessWidget {
+  /// Warning used when point placed outside project polygon on test.
   const OutsideBoundsWarning({
     super.key,
   });
@@ -495,11 +535,11 @@ class OutsideBoundsWarning extends StatelessWidget {
   }
 }
 
-/// A row with a small circle of [color] followed by [Text(label)].
 class ColorLegendItem extends StatelessWidget {
   final String label;
   final Color color;
 
+  /// A row with a small circle of [color] followed by [Text(label)].
   const ColorLegendItem({
     super.key,
     required this.label,
@@ -652,12 +692,12 @@ class DataEditMenu extends StatelessWidget {
   }
 }
 
-/// Dialog for test finish confirmation.
-///
-/// Takes only an [onNext] parameter. This should contain the function to be
-/// called when finish the test (i.e. saving the data, pushing to the next
-/// page).
 class TestFinishDialog extends StatelessWidget {
+  /// Dialog for test finish confirmation.
+  ///
+  /// Takes only an [onNext] parameter. This should contain the function to be
+  /// called when finish the test (i.e. saving the data, pushing to the next
+  /// page).
   const TestFinishDialog({
     super.key,
     required this.onNext,
@@ -696,93 +736,100 @@ class TestFinishDialog extends StatelessWidget {
   }
 }
 
-class DirectionsWidget extends StatelessWidget {
+class DirectionsButton extends StatelessWidget {
   /// Directions widget used for tests.
   ///
   /// Pass through a [visibility] variable. This should be of type [bool] and
   /// control the visibility of the directions. The [onTap] function passed
   /// should toggle the [visibility] boolean in a [setState]. It may do other
-  /// things on top of this if desired. The [text] should be the directions
-  /// variable which controls the text to display.
+  /// things on top of this if desired.
   /// Should be placed in a Column w/ other widgets (delete mode, map type)
-  const DirectionsWidget({
+  const DirectionsButton({
     super.key,
     required this.onTap,
-    required this.text,
     required this.visibility,
     this.buttonPadding,
   });
 
   final VoidCallback? onTap;
   final EdgeInsets? buttonPadding;
-  final String text;
   final bool visibility;
 
   @override
   Widget build(BuildContext context) {
-    return visibility
-        ? Padding(
-            padding:
-                const EdgeInsets.symmetric(vertical: 20.0, horizontal: 25.0),
-            child: InkWell(
-              onTap: onTap,
-              child: Container(
-                  padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: directionsTransparency,
-                    gradient: defaultGrad,
-                    borderRadius: const BorderRadius.all(Radius.circular(10)),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.1),
-                        blurRadius: 6,
-                        offset: const Offset(0, 2),
-                      ),
-                    ],
-                  ),
-                  child: Text(
-                    text,
-                    maxLines: 3,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w500,
-                      color: Colors.white,
-                    ),
-                  )),
+    return Container(
+      decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(Radius.circular(50)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.1),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
             ),
-          )
-        : Container(
-            decoration: BoxDecoration(
-                borderRadius: const BorderRadius.all(Radius.circular(50)),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.1),
-                    blurRadius: 6,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
-                gradient: defaultGrad,
-                color: directionsTransparency),
-            child: IconButton(
-                color: Colors.white,
-                onPressed: onTap,
-                icon: Icon(
-                  Icons.help_outline,
-                  size: 35,
-                )),
-          );
+          ],
+          gradient: defaultGrad,
+          color: directionsTransparency),
+      child: IconButton(
+          color: Colors.white,
+          onPressed: onTap,
+          icon: Icon(
+            Icons.help_outline,
+            size: 35,
+          )),
+    );
   }
 }
 
-/// Visibility switch widget for tests page.
-///
-/// Toggles visibility for the old shapes on test pages. Takes in a [visibility]
-/// variable and an [onChanged] function. The [onChanged] function is of type
-/// [Function(bool)?]. It takes a [bool] parameter and should change the
-/// [visibility] variable to the value of the [bool] parameter. Should be in a
-/// [setState].
+class DirectionsText extends StatelessWidget {
+  const DirectionsText({
+    super.key,
+    required this.onTap,
+    required this.text,
+  });
+
+  final VoidCallback? onTap;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+          padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+          decoration: BoxDecoration(
+            color: directionsTransparency,
+            gradient: defaultGrad,
+            borderRadius: const BorderRadius.all(Radius.circular(10)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.1),
+                blurRadius: 6,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Text(
+            text,
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w500,
+              color: Colors.white,
+            ),
+          )),
+    );
+  }
+}
+
 class VisibilitySwitch extends StatelessWidget {
+  /// Visibility switch widget for tests page.
+  ///
+  /// Toggles visibility for the old shapes on test pages. Takes in a [visibility]
+  /// variable and an [onChanged] function. The [onChanged] function is of type
+  /// [Function(bool)?]. It takes a [bool] parameter and should change the
+  /// [visibility] variable to the value of the [bool] parameter. Should be in a
+  /// [setState].
   const VisibilitySwitch({
     super.key,
     required bool visibility,
@@ -959,11 +1006,11 @@ void showTestModalGeneric(BuildContext context,
       });
 }
 
-/// Error text for test pages.
-///
-/// Displays a text error at bottom of screen with the text specified by the
-/// [text] parameter. Defaults to point placed outside of polygon error text.
 class TestErrorText extends StatelessWidget {
+  /// Error text for test pages.
+  ///
+  /// Displays a text error at bottom of screen with the text specified by the
+  /// [text] parameter. Defaults to point placed outside of polygon error text.
   const TestErrorText({
     this.text,
     super.key,


### PR DESCRIPTION
Test Changes:
- Added functional delete mode to Nature Prevalence.
- Added delete mode to Identifying Access.
- Changed maps and delete widget to standard circular widget, and move to top right to match people tests.
- Added Null checking for project_details_page.dart dialog changes.
- Fixed polyline marker deletion logic on section_creation_page.dart.
- Directions now start off, instead of on.
- Fixed nature_prevalence_test.dart dialog widget and added text alignment for dialog text box widget.
- Added two optional, named parameters to finalizePolygon in google_maps_functions.dart.
- Placed Directions widget in a column with other widgets of similar type (delete, map type), and then aligned/padded the column instead.

Timer:

- Added functional timer to Nature Prevalence test.
- Added functionality for timer ending.
- Hooked up timers to backend.
 - Each test that uses timers has been hooked up appropriately in the backend.
 - Nature Prevalence has timer fully implemented in backend and frontend implementation.
 - Create Test form has been changed to accommodate timer creation.
 - Prevented placing data before timer has been started.
 - Created timer widget. Contains both timer and display together.
- Changed formatting on nature_prevalence_test.dart.
- Formatting needs work on Section Cutter and Creation, along with Identifying Access.
