### PR TITLE
Update layouts and finetune some of the recently added widgets.

### DIFF
--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -51,19 +51,21 @@ class AbsenceOfOrderTestPage extends StatefulWidget {
 class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
   bool _isLoading = true;
   bool _outsidePoint = false;
+  bool _isTestRunning = false;
+  bool _directionsVisible = false;
 
   late GoogleMapController mapController;
   LatLng _location = defaultLocation;
   double _zoom = 18;
   MapType _currentMapType = MapType.satellite; // Default map type
   List<mp.LatLng> _projectArea = [];
-
   final Set<Marker> _markers = {}; // Set of markers visible on map
   final Set<Polygon> _polygons = {}; // Set of polygons
   final AbsenceOfOrderData _newData = AbsenceOfOrderData();
   DataPoint? _tempDataPoint;
 
-  static const double _bottomSheetHeight = 220;
+  int _remainingSeconds = -1;
+  static const double _bottomSheetHeight = 165;
 
   @override
   void initState() {
@@ -106,6 +108,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
           mp.LatLng(point.latitude, point.longitude), _projectArea, true)) {
         setState(() {
           _outsidePoint = true;
+          print('outside!');
         });
       }
       // Add point to data and then add to AbsenceOfOrderData list
@@ -171,6 +174,11 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
     });
   }
 
+  void _endTest() {
+    widget.activeTest.submitData(_newData);
+    Navigator.pop(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     // Updates flag for whether _tempDataPoint has a description for data point
@@ -181,189 +189,205 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
         extendBody: true,
         body: _isLoading
             ? const Center(child: CircularProgressIndicator())
-            : Center(
-                child: Stack(
-                  children: <Widget>[
-                    SizedBox(
-                      height: MediaQuery.of(context).size.height,
-                      child: GoogleMap(
-                        padding: EdgeInsets.only(bottom: _bottomSheetHeight),
-                        onMapCreated: _onMapCreated,
-                        initialCameraPosition:
-                            CameraPosition(target: _location, zoom: _zoom),
-                        markers: _markers,
-                        polygons: _polygons,
-                        onTap: isDescriptionReady ? _togglePoint : null,
-                        mapType: _currentMapType,
+            : Stack(
+                children: <Widget>[
+                  SizedBox(
+                    height: MediaQuery.of(context).size.height,
+                    child: GoogleMap(
+                      padding: EdgeInsets.only(bottom: _bottomSheetHeight),
+                      onMapCreated: _onMapCreated,
+                      initialCameraPosition:
+                          CameraPosition(target: _location, zoom: _zoom),
+                      markers: _markers,
+                      polygons: _polygons,
+                      onTap: isDescriptionReady ? _togglePoint : null,
+                      mapType: _currentMapType,
+                    ),
+                  ),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Padding(
+                        padding: const EdgeInsets.only(top: 15.0, left: 15.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            TimerButtonAndDisplay(
+                              onPressed: () {},
+                              testIsRunning: _isTestRunning,
+                              remainingSeconds: _remainingSeconds,
+                            )
+                          ],
+                        ),
+                      ),
+                      Flexible(
+                        child: _directionsVisible
+                            ? Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 15.0, vertical: 15.0),
+                                child: DirectionsText(
+                                    onTap: () {
+                                      setState(() {
+                                        _directionsVisible =
+                                            !_directionsVisible;
+                                      });
+                                    },
+                                    text: !isDescriptionReady
+                                        ? 'Select a type of misconduct.'
+                                        : 'Drop a pin where the misconduct is.'),
+                              )
+                            : SizedBox(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 15, right: 15),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          spacing: 10,
+                          children: <Widget>[
+                            Align(
+                              alignment: Alignment.topRight,
+                              child: DirectionsButton(
+                                onTap: () {
+                                  setState(() {
+                                    _directionsVisible = !_directionsVisible;
+                                  });
+                                },
+                              ),
+                            ),
+                            Align(
+                              alignment: Alignment.topRight,
+                              child: CircularIconMapButton(
+                                backgroundColor: Colors.green,
+                                borderColor: Color(0xFF2D6040),
+                                onPressed: _toggleMapType,
+                                icon: const Icon(Icons.map),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.only(
+                        left: 10,
+                        right: 10,
+                        bottom: _bottomSheetHeight + 30,
+                      ),
+                      child: FloatingActionButton(
+                        heroTag: null,
+                        onPressed: _toggleMapType,
+                        backgroundColor: Colors.green,
+                        child: const Icon(Icons.map),
                       ),
                     ),
-                    Align(
-                      alignment: Alignment.bottomLeft,
-                      child: Padding(
-                        padding: const EdgeInsets.only(
-                          left: 10,
-                          right: 10,
-                          bottom: _bottomSheetHeight + 30,
-                        ),
-                        child: FloatingActionButton(
-                          heroTag: null,
-                          onPressed: _toggleMapType,
-                          backgroundColor: Colors.green,
-                          child: const Icon(Icons.map),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
         bottomSheet: _isLoading
             ? SizedBox()
             : SizedBox(
                 height: _bottomSheetHeight,
-                child: Stack(
-                  children: <Widget>[
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0, vertical: 10.0),
-                      decoration: BoxDecoration(
-                        gradient: defaultGrad,
-                        borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(24.0),
-                          topRight: Radius.circular(24.0),
-                        ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black,
-                            offset: Offset(0.0, 1.0), //(x,y)
-                            blurRadius: 6.0,
-                          ),
-                        ],
-                      ),
-                      child: Column(
-                        children: <Widget>[
-                          Center(
-                            child: Text(
-                              'Absence of Order Locator',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: placeYellow,
-                              ),
-                            ),
-                          ),
-                          SizedBox(height: 5),
-                          Center(
-                            child: Text(
-                              !isDescriptionReady
-                                  ? 'Select a type of misconduct.'
-                                  : 'Drop a pin where the misconduct is.',
-                              style: TextStyle(
-                                fontSize: 20,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                          SizedBox(height: 5),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            spacing: 10,
-                            children: <Widget>[
-                              Expanded(
-                                child: FilledButton(
-                                  style: testButtonStyle,
-                                  onPressed: isDescriptionReady
-                                      ? null
-                                      : () {
-                                          _doBehaviorModal(context);
-                                        },
-                                  child: Text('Behavior'),
-                                ),
-                              ),
-                              Expanded(
-                                child: FilledButton(
-                                  style: testButtonStyle,
-                                  onPressed: isDescriptionReady
-                                      ? null
-                                      : () {
-                                          _doMaintenanceModal(context);
-                                        },
-                                  child: Text('Maintenance'),
-                                ),
-                              ),
-                            ],
-                          ),
-                          SizedBox(height: 15),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            spacing: 10,
-                            children: <Widget>[
-                              Flexible(
-                                child: FilledButton.icon(
-                                  style: testButtonStyle,
-                                  onPressed: () => Navigator.pop(context),
-                                  label: Text('Back'),
-                                  icon: Icon(Icons.chevron_left),
-                                  iconAlignment: IconAlignment.start,
-                                ),
-                              ),
-                              Flexible(
-                                child: FilledButton.icon(
-                                  style: testButtonStyle,
-                                  onPressed: (isDescriptionReady)
-                                      ? null
-                                      : () {
-                                          // TODO: check isComplete either before submitting or probably before starting test
-                                          widget.activeTest
-                                              .submitData(_newData);
-                                          Navigator.pop(context);
-                                        },
-                                  label: Text('Finish'),
-                                  icon: Icon(Icons.chevron_right),
-                                  iconAlignment: IconAlignment.end,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12.0, vertical: 10.0),
+                  decoration: BoxDecoration(
+                    gradient: defaultGrad,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(24.0),
+                      topRight: Radius.circular(24.0),
                     ),
-                    _outsidePoint
-                        ? Align(
-                            alignment: Alignment.bottomCenter,
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                  vertical: 30.0, horizontal: 100.0),
-                              child: Container(
-                                padding: EdgeInsets.symmetric(
-                                    horizontal: 15, vertical: 10),
-                                decoration: BoxDecoration(
-                                  color: Colors.red[900],
-                                  borderRadius: const BorderRadius.all(
-                                      Radius.circular(10)),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color:
-                                          Colors.black.withValues(alpha: 0.1),
-                                      blurRadius: 6,
-                                      offset: const Offset(0, 2),
-                                    ),
-                                  ],
-                                ),
-                                child: Text(
-                                  'You have placed a point outside of the project area!',
-                                  maxLines: 3,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.w500,
-                                    color: Colors.red[50],
-                                  ),
-                                ),
-                              ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black,
+                        offset: Offset(0.0, 1.0), //(x,y)
+                        blurRadius: 6.0,
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    children: <Widget>[
+                      Center(
+                        child: Text(
+                          'Absence of Order Locator',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                            color: placeYellow,
+                          ),
+                        ),
+                      ),
+                      SizedBox(height: 5),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        spacing: 10,
+                        children: <Widget>[
+                          Expanded(
+                            child: FilledButton(
+                              style: testButtonStyle,
+                              onPressed: isDescriptionReady
+                                  ? null
+                                  : () {
+                                      _doBehaviorModal(context);
+                                    },
+                              child: Text('Behavior'),
                             ),
-                          )
-                        : SizedBox(),
-                  ],
+                          ),
+                          Expanded(
+                            child: FilledButton(
+                              style: testButtonStyle,
+                              onPressed: isDescriptionReady
+                                  ? null
+                                  : () {
+                                      _doMaintenanceModal(context);
+                                    },
+                              child: Text('Maintenance'),
+                            ),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: 15),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        spacing: 10,
+                        children: <Widget>[
+                          Flexible(
+                            child: FilledButton.icon(
+                              style: testButtonStyle,
+                              onPressed: () => Navigator.pop(context),
+                              label: Text('Back'),
+                              icon: Icon(Icons.chevron_left),
+                              iconAlignment: IconAlignment.start,
+                            ),
+                          ),
+                          Flexible(
+                            child: FilledButton.icon(
+                              style: testButtonStyle,
+                              onPressed: (isDescriptionReady)
+                                  ? null
+                                  : () {
+                                      showDialog(
+                                          context: context,
+                                          builder: (context) =>
+                                              TestFinishDialog(onNext: () {
+                                                Navigator.pop(context);
+                                                _endTest();
+                                              }));
+                                    },
+                              label: Text('Finish'),
+                              icon: Icon(Icons.chevron_right),
+                              iconAlignment: IconAlignment.end,
+                            ),
+                          ),
+                        ],
+                      ),
+                      _outsidePoint ? TestErrorText() : SizedBox(),
+                    ],
+                  ),
                 ),
               ),
       ),

--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -192,7 +192,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
             : Stack(
                 children: <Widget>[
                   SizedBox(
-                    height: MediaQuery.of(context).size.height,
+                    height: MediaQuery.sizeOf(context).height,
                     child: GoogleMap(
                       padding: EdgeInsets.only(bottom: _bottomSheetHeight),
                       onMapCreated: _onMapCreated,
@@ -210,19 +210,17 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                     children: <Widget>[
                       Padding(
                         padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            TimerButtonAndDisplay(
-                              onPressed: () {},
-                              testIsRunning: _isTestRunning,
-                              remainingSeconds: _remainingSeconds,
-                            )
-                          ],
+                        child: TimerButtonAndDisplay(
+                          onPressed: () {
+                            setState(() {
+                              _isTestRunning = !_isTestRunning;
+                            });
+                          },
+                          isTestRunning: _isTestRunning,
+                          remainingSeconds: _remainingSeconds,
                         ),
                       ),
-                      Flexible(
+                      Expanded(
                         child: _directionsVisible
                             ? Padding(
                                 padding: const EdgeInsets.symmetric(
@@ -243,49 +241,32 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                       Padding(
                         padding: const EdgeInsets.only(top: 15, right: 15),
                         child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.end,
                           spacing: 10,
                           children: <Widget>[
-                            Align(
-                              alignment: Alignment.topRight,
-                              child: DirectionsButton(
-                                onTap: () {
-                                  setState(() {
-                                    _directionsVisible = !_directionsVisible;
-                                  });
-                                },
-                              ),
+                            DirectionsButton(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
                             ),
-                            Align(
-                              alignment: Alignment.topRight,
-                              child: CircularIconMapButton(
-                                backgroundColor: Colors.green,
-                                borderColor: Color(0xFF2D6040),
-                                onPressed: _toggleMapType,
-                                icon: const Icon(Icons.map),
-                              ),
+                            CircularIconMapButton(
+                              backgroundColor: Colors.green,
+                              borderColor: Color(0xFF2D6040),
+                              onPressed: _toggleMapType,
+                              icon: const Icon(Icons.map),
                             ),
                           ],
                         ),
                       ),
                     ],
                   ),
-                  Align(
-                    alignment: Alignment.bottomLeft,
-                    child: Padding(
-                      padding: const EdgeInsets.only(
-                        left: 10,
-                        right: 10,
-                        bottom: _bottomSheetHeight + 30,
-                      ),
-                      child: FloatingActionButton(
-                        heroTag: null,
-                        onPressed: _toggleMapType,
-                        backgroundColor: Colors.green,
-                        child: const Icon(Icons.map),
-                      ),
+                  if (_outsidePoint)
+                    Padding(
+                      padding:
+                          const EdgeInsets.only(bottom: _bottomSheetHeight),
+                      child: TestErrorText(),
                     ),
-                  ),
                 ],
               ),
         bottomSheet: _isLoading
@@ -385,7 +366,6 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                           ),
                         ],
                       ),
-                      _outsidePoint ? TestErrorText() : SizedBox(),
                     ],
                   ),
                 ),

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -346,12 +346,12 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                           mainAxisAlignment: MainAxisAlignment.start,
                           children: [
                             DirectionsButton(
-                                onTap: () {
-                                  setState(() {
-                                    _directionsVisible = !_directionsVisible;
-                                  });
-                                },
-                                visibility: _directionsVisible),
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
+                            ),
                             CircularIconMapButton(
                               backgroundColor: Colors.green,
                               borderColor: Color(0xFF2D6040),

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -289,61 +289,56 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
         resizeToAvoidBottomInset: false,
         body: _isLoading
             ? const Center(child: CircularProgressIndicator())
-            : Center(
-                child: Stack(
-                  children: [
-                    SizedBox(
-                      height: MediaQuery.of(context).size.height,
-                      child: GoogleMap(
-                        // TODO: size based off of bottomsheet container
-                        polylines: _currentPolyline == null
-                            ? (_oldPolylinesToggle ? _polylines : {})
-                            : (_oldPolylinesToggle
-                                ? {..._polylines, _currentPolyline!}
-                                : {_currentPolyline!}),
-                        padding: EdgeInsets.only(bottom: _bottomSheetHeight),
-                        onMapCreated: _onMapCreated,
-                        initialCameraPosition:
-                            CameraPosition(target: _location, zoom: _zoom),
-                        polygons: _oldPolylinesToggle
-                            ? {
-                                ..._projectArea,
-                                ..._polygons,
-                                ..._currentPolygon
-                              }
-                            : {..._projectArea, ..._currentPolygon},
-                        markers: {
-                          ..._markers,
-                          ..._polygonMarkers,
-                          ..._visiblePolylineMarkers
-                        },
-                        onTap: _togglePoint,
-                        mapType: _currentMapType, // Use current map type
+            : Stack(
+                children: [
+                  SizedBox(
+                    height: MediaQuery.sizeOf(context).height,
+                    child: GoogleMap(
+                      polylines: _currentPolyline == null
+                          ? (_oldPolylinesToggle ? _polylines : {})
+                          : (_oldPolylinesToggle
+                              ? {..._polylines, _currentPolyline!}
+                              : {_currentPolyline!}),
+                      padding: EdgeInsets.only(bottom: _bottomSheetHeight),
+                      onMapCreated: _onMapCreated,
+                      initialCameraPosition:
+                          CameraPosition(target: _location, zoom: _zoom),
+                      polygons: _oldPolylinesToggle
+                          ? {..._projectArea, ..._polygons, ..._currentPolygon}
+                          : {..._projectArea, ..._currentPolygon},
+                      markers: {
+                        ..._markers,
+                        ..._polygonMarkers,
+                        ..._visiblePolylineMarkers
+                      },
+                      onTap: _togglePoint,
+                      mapType: _currentMapType, // Use current map type
+                    ),
+                  ),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Expanded(
+                        child: _directionsVisible
+                            ? Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 15.0, vertical: 15.0),
+                                child: DirectionsText(
+                                    onTap: () {
+                                      setState(() {
+                                        _directionsVisible =
+                                            !_directionsVisible;
+                                      });
+                                    },
+                                    text: _directions),
+                              )
+                            : SizedBox(),
                       ),
-                    ),
-                    Align(
-                      alignment: Alignment.topCenter,
-                      child: _directionsVisible
-                          ? Padding(
-                              padding:
-                                  const EdgeInsets.only(top: 15.0, right: 15.0),
-                              child: DirectionsText(
-                                  onTap: () {
-                                    setState(() {
-                                      _directionsVisible = !_directionsVisible;
-                                    });
-                                  },
-                                  text: _directions),
-                            )
-                          : SizedBox(),
-                    ),
-                    Align(
-                      alignment: Alignment.topRight,
-                      child: Padding(
+                      Padding(
                         padding: const EdgeInsets.only(top: 15.0, right: 15.0),
                         child: Column(
                           spacing: 10,
-                          mainAxisAlignment: MainAxisAlignment.start,
                           children: [
                             DirectionsButton(
                               onTap: () {
@@ -358,46 +353,51 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                               onPressed: _toggleMapType,
                               icon: const Icon(Icons.map),
                             ),
-                            (!_polygonMode && !_pointMode && !_polylineMode)
-                                ? CircularIconMapButton(
-                                    borderColor: Color(0xFF2D6040),
-                                    onPressed: () {
-                                      setState(() {
-                                        _deleteMode = !_deleteMode;
-                                      });
-                                    },
-                                    backgroundColor:
-                                        _deleteMode ? Colors.blue : Colors.red,
-                                    icon: Icon(
-                                      _deleteMode
-                                          ? Icons.location_on
-                                          : Icons.delete,
-                                      size: 30,
-                                    ),
-                                  )
-                                : SizedBox(),
+                            if (!_polygonMode && !_pointMode && !_polylineMode)
+                              CircularIconMapButton(
+                                borderColor: Color(0xFF2D6040),
+                                onPressed: () {
+                                  setState(() {
+                                    _deleteMode = !_deleteMode;
+                                  });
+                                },
+                                backgroundColor:
+                                    _deleteMode ? Colors.blue : Colors.red,
+                                icon: Icon(
+                                  _deleteMode
+                                      ? Icons.location_on
+                                      : Icons.delete,
+                                  size: 30,
+                                ),
+                              ),
                           ],
                         ),
                       ),
-                    ),
-                    Align(
-                      alignment: Alignment.bottomLeft,
-                      child: Padding(
-                        padding: EdgeInsets.only(
-                            bottom: _bottomSheetHeight + 35, left: 5),
-                        child: VisibilitySwitch(
-                          visibility: _oldPolylinesToggle,
-                          onChanged: (value) {
-                            // This is called when the user toggles the switch.
-                            setState(() {
-                              _oldPolylinesToggle = value;
-                            });
-                          },
-                        ),
+                    ],
+                  ),
+                  Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Padding(
+                      padding: EdgeInsets.only(
+                          bottom: _bottomSheetHeight + 35, left: 5),
+                      child: VisibilitySwitch(
+                        visibility: _oldPolylinesToggle,
+                        onChanged: (value) {
+                          // This is called when the user toggles the switch.
+                          setState(() {
+                            _oldPolylinesToggle = value;
+                          });
+                        },
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                  if (_deleteMode)
+                    TestErrorText(
+                      padding: EdgeInsets.fromLTRB(
+                          20, 0, 20, _bottomSheetHeight + 30),
+                      text: "You are in delete mode.",
+                    ),
+                ],
               ),
         bottomSheet: _isLoading
             ? SizedBox()
@@ -664,9 +664,6 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                         ],
                       ),
                     ),
-                    _deleteMode
-                        ? TestErrorText(text: "You are in delete mode.")
-                        : SizedBox(),
                   ],
                 ),
               ),

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -868,29 +868,23 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                     children: <Widget>[
                       Padding(
                         padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            TimerButtonAndDisplay(
-                              onPressed: () {
-                                if (_isTestRunning) {
-                                  setState(() {
-                                    _isTestRunning = false;
-                                    _timer?.cancel();
-                                    _clearTypes();
-                                  });
-                                } else {
-                                  _startTest();
-                                }
-                              },
-                              testIsRunning: _isTestRunning,
-                              remainingSeconds: _remainingSeconds,
-                            )
-                          ],
+                        child: TimerButtonAndDisplay(
+                          onPressed: () {
+                            if (_isTestRunning) {
+                              setState(() {
+                                _isTestRunning = false;
+                                _timer?.cancel();
+                                _clearTypes();
+                              });
+                            } else {
+                              _startTest();
+                            }
+                          },
+                          isTestRunning: _isTestRunning,
+                          remainingSeconds: _remainingSeconds,
                         ),
                       ),
-                      Flexible(
+                      Expanded(
                         child: _directionsVisible
                             ? Padding(
                                 padding: const EdgeInsets.symmetric(
@@ -909,56 +903,45 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                       Padding(
                         padding: const EdgeInsets.only(top: 15.0, right: 15.0),
                         child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.end,
                           spacing: 10,
                           children: [
-                            Align(
-                              alignment: Alignment.topRight,
-                              child: DirectionsButton(
-                                onTap: () {
-                                  setState(() {
-                                    _directionsVisible = !_directionsVisible;
-                                  });
-                                },
-                              ),
+                            DirectionsButton(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
                             ),
-                            Align(
-                              alignment: Alignment.topRight,
-                              child: CircularIconMapButton(
-                                backgroundColor: Colors.green,
-                                borderColor: Color(0xFF2D6040),
-                                onPressed: _toggleMapType,
-                                icon: const Icon(Icons.map),
-                              ),
+                            CircularIconMapButton(
+                              backgroundColor: Colors.green,
+                              borderColor: Color(0xFF2D6040),
+                              onPressed: _toggleMapType,
+                              icon: const Icon(Icons.map),
                             ),
                             (!_polygonMode && !_pointMode)
-                                ? Align(
-                                    alignment: Alignment.topRight,
-                                    child: CircularIconMapButton(
-                                      borderColor: Color(0xFF2D6040),
-                                      onPressed: () {
-                                        setState(() {
-                                          _deleteMode = !_deleteMode;
-                                          if (_deleteMode == true) {
-                                            _outsidePoint = false;
-                                            _errorText =
-                                                'You are in delete mode.';
-                                          } else {
-                                            _outsidePoint = false;
-                                            _errorText =
-                                                'You tried to place a point outside of the project area!';
-                                          }
-                                        });
-                                      },
-                                      backgroundColor: _deleteMode
-                                          ? Colors.blue
-                                          : Colors.red,
-                                      icon: Icon(
-                                        _deleteMode
-                                            ? Icons.location_on
-                                            : Icons.delete,
-                                        size: 30,
-                                      ),
+                                ? CircularIconMapButton(
+                                    borderColor: Color(0xFF2D6040),
+                                    onPressed: () {
+                                      setState(() {
+                                        _deleteMode = !_deleteMode;
+                                        if (_deleteMode == true) {
+                                          _outsidePoint = false;
+                                          _errorText =
+                                              'You are in delete mode.';
+                                        } else {
+                                          _outsidePoint = false;
+                                          _errorText =
+                                              'You tried to place a point outside of the project area!';
+                                        }
+                                      });
+                                    },
+                                    backgroundColor:
+                                        _deleteMode ? Colors.blue : Colors.red,
+                                    icon: Icon(
+                                      _deleteMode
+                                          ? Icons.location_on
+                                          : Icons.delete,
+                                      size: 30,
                                     ),
                                   )
                                 : SizedBox(),
@@ -983,6 +966,12 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                       ),
                     ),
                   ),
+                  if (_outsidePoint || _deleteMode)
+                    TestErrorText(
+                      text: _errorText,
+                      padding: EdgeInsets.fromLTRB(
+                          20, 0, 20, _bottomSheetHeight + 30),
+                    ),
                 ],
               ),
         bottomSheet: _isLoading
@@ -1177,9 +1166,6 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                         ],
                       ),
                     ),
-                    (_outsidePoint || _deleteMode)
-                        ? TestErrorText(text: _errorText)
-                        : SizedBox(),
                   ],
                 ),
               ),

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -51,7 +51,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
 
   Timer? _timer;
   int _remainingSeconds = -1;
-  bool _testIsRunning = false;
+  bool _isTestRunning = false;
 
   final NatureData _natureData = NatureData();
 
@@ -93,13 +93,13 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
 
   void _startTest() {
     setState(() {
-      _testIsRunning = true;
+      _isTestRunning = true;
     });
     _timer = Timer.periodic(Duration(seconds: 1), (timer) {
       setState(() {
         _remainingSeconds--;
         if (_remainingSeconds <= 0) {
-          _testIsRunning = false;
+          _isTestRunning = false;
           timer.cancel();
           showDialog(
             context: context,
@@ -874,9 +874,9 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                           children: <Widget>[
                             TimerButtonAndDisplay(
                               onPressed: () {
-                                if (_testIsRunning) {
+                                if (_isTestRunning) {
                                   setState(() {
-                                    _testIsRunning = false;
+                                    _isTestRunning = false;
                                     _timer?.cancel();
                                     _clearTypes();
                                   });
@@ -884,7 +884,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                   _startTest();
                                 }
                               },
-                              testIsRunning: _testIsRunning,
+                              testIsRunning: _isTestRunning,
                               remainingSeconds: _remainingSeconds,
                             )
                           ],
@@ -915,12 +915,12 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                             Align(
                               alignment: Alignment.topRight,
                               child: DirectionsButton(
-                                  onTap: () {
-                                    setState(() {
-                                      _directionsVisible = !_directionsVisible;
-                                    });
-                                  },
-                                  visibility: _directionsVisible),
+                                onTap: () {
+                                  setState(() {
+                                    _directionsVisible = !_directionsVisible;
+                                  });
+                                },
+                              ),
                             ),
                             Align(
                               alignment: Alignment.topRight,
@@ -1039,7 +1039,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                   onPressed: (_pointMode ||
                                           _polygonMode ||
                                           _deleteMode ||
-                                          !_testIsRunning)
+                                          !_isTestRunning)
                                       ? null
                                       : () {
                                           showModalAnimal(context);
@@ -1050,7 +1050,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                   onPressed: (_pointMode ||
                                           _polygonMode ||
                                           _deleteMode ||
-                                          !_testIsRunning)
+                                          !_isTestRunning)
                                       ? null
                                       : () {
                                           showModalVegetation(context);
@@ -1079,7 +1079,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                   onPressed: (_pointMode ||
                                           _polygonMode ||
                                           _deleteMode ||
-                                          !_testIsRunning)
+                                          !_isTestRunning)
                                       ? null
                                       : () {
                                           showModalWaterBody(context);
@@ -1155,7 +1155,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                                       onPressed: (_pointMode ||
                                               _polygonMode ||
                                               _deleteMode ||
-                                              _testIsRunning)
+                                              _isTestRunning)
                                           ? null
                                           : () {
                                               showDialog(

--- a/lib/section_creation_page.dart
+++ b/lib/section_creation_page.dart
@@ -131,28 +131,45 @@ class _SectionCreationPageState extends State<SectionCreationPage> {
             : Stack(
                 children: [
                   SizedBox(
-                    height: MediaQuery.of(context).size.height,
-                    child: Stack(
-                      children: [
-                        GoogleMap(
-                          onMapCreated: _onMapCreated,
-                          initialCameraPosition:
-                              CameraPosition(target: _location, zoom: _zoom),
-                          polygons: _polygons,
-                          polylines: {if (_polyline != null) _polyline!},
-                          markers: (_markers.isNotEmpty)
-                              ? {_markers.first, _markers.last}
-                              : {},
-                          mapType: _currentMapType, // Use current map type
-                          onTap: _polylineTap,
-                        ),
-                        Row(
-                          children: [
-                            Center(
+                    height: MediaQuery.sizeOf(context).height,
+                    child: GoogleMap(
+                      onMapCreated: _onMapCreated,
+                      initialCameraPosition:
+                          CameraPosition(target: _location, zoom: _zoom),
+                      polygons: _polygons,
+                      polylines: {if (_polyline != null) _polyline!},
+                      markers: (_markers.isNotEmpty)
+                          ? {_markers.first, _markers.last}
+                          : {},
+                      mapType: _currentMapType, // Use current map type
+                      onTap: _polylineTap,
+                    ),
+                  ),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(
+                        child: _directionsVisible
+                            ? Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 15.0, vertical: 15.0),
                                 child: DirectionsText(
-                              onTap: () {},
-                              text: _directions,
-                            )),
+                                  onTap: () {
+                                    setState(() {
+                                      _directionsVisible = !_directionsVisible;
+                                    });
+                                  },
+                                  text: _directions,
+                                ),
+                              )
+                            : SizedBox(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 15, right: 15),
+                        child: Column(
+                          spacing: 10,
+                          children: <Widget>[
                             DirectionsButton(
                               onTap: () {
                                 setState(() {
@@ -160,16 +177,14 @@ class _SectionCreationPageState extends State<SectionCreationPage> {
                                 });
                               },
                             ),
-                          ],
-                        ),
-                        Align(
-                          alignment: Alignment.bottomLeft,
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                                left: 10.0, bottom: 130.0),
-                            child: FloatingActionButton(
-                              tooltip: 'Clear all.',
-                              heroTag: null,
+                            CircularIconMapButton(
+                              backgroundColor: Colors.green,
+                              borderColor: Color(0xFF2D6040),
+                              onPressed: _toggleMapType,
+                              icon: const Icon(Icons.map),
+                            ),
+                            CircularIconMapButton(
+                              borderColor: Color(0xFF2D6040),
                               onPressed: () {
                                 setState(() {
                                   _markers = {};
@@ -181,68 +196,54 @@ class _SectionCreationPageState extends State<SectionCreationPage> {
                                 });
                               },
                               backgroundColor: Colors.red,
-                              child: Icon(
+                              icon: Icon(
                                 Icons.delete_sweep,
                                 size: 30,
                               ),
-                            ),
-                          ),
+                            )
+                          ],
                         ),
-                        Align(
-                          alignment: Alignment.bottomLeft,
-                          child: Padding(
-                            padding: EdgeInsets.only(left: 10.0, bottom: 50),
-                            child: FloatingActionButton(
-                              tooltip: 'Change map type.',
-                              onPressed: _toggleMapType,
-                              backgroundColor: Colors.green,
-                              child: const Icon(Icons.map),
-                            ),
+                      ),
+                    ],
+                  ),
+                  Padding(
+                    padding: EdgeInsets.only(bottom: 5),
+                    child: Align(
+                      alignment: Alignment.bottomCenter,
+                      child: FilledButton.icon(
+                        style: FilledButton.styleFrom(
+                          padding: const EdgeInsets.only(left: 15, right: 15),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(15.0),
                           ),
+                          elevation: 3.0,
+                          shadowColor: Colors.black,
+                          foregroundColor: Colors.white,
+                          backgroundColor: Colors.black,
+                          iconColor: Colors.white,
+                          disabledBackgroundColor: disabledGrey,
                         ),
-                        Padding(
-                          padding: EdgeInsets.only(bottom: 5),
-                          child: Align(
-                            alignment: Alignment.bottomCenter,
-                            child: FilledButton.icon(
-                              style: FilledButton.styleFrom(
-                                padding:
-                                    const EdgeInsets.only(left: 15, right: 15),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(15.0),
-                                ),
-                                elevation: 3.0,
-                                shadowColor: Colors.black,
-                                foregroundColor: Colors.white,
-                                backgroundColor: Colors.black,
-                                iconColor: Colors.white,
-                                disabledBackgroundColor: disabledGrey,
-                              ),
-                              onPressed: _isLoading
-                                  ? null
-                                  : () {
-                                      try {
-                                        setState(() {
-                                          _isLoading = true;
-                                        });
-                                        Navigator.pop(
-                                            context, _polyline?.points);
-                                      } catch (e, stacktrace) {
-                                        print(
-                                            "Exception in confirming section (section_creation_point.dart): $e");
-                                        print("Stacktrace: $stacktrace");
-                                      }
-                                    },
-                              label: Text('Confirm'),
-                              icon: const Icon(Icons.check),
-                              iconAlignment: IconAlignment.end,
-                            ),
-                          ),
-                        ),
-                        _outsidePoint ? TestErrorText() : SizedBox(),
-                      ],
+                        onPressed: _isLoading
+                            ? null
+                            : () {
+                                try {
+                                  setState(() {
+                                    _isLoading = true;
+                                  });
+                                  Navigator.pop(context, _polyline?.points);
+                                } catch (e, stacktrace) {
+                                  print(
+                                      "Exception in confirming section (section_creation_point.dart): $e");
+                                  print("Stacktrace: $stacktrace");
+                                }
+                              },
+                        label: Text('Confirm'),
+                        icon: const Icon(Icons.check),
+                        iconAlignment: IconAlignment.end,
+                      ),
                     ),
                   ),
+                  _outsidePoint ? TestErrorText() : SizedBox(),
                 ],
               ),
       ),

--- a/lib/section_creation_page.dart
+++ b/lib/section_creation_page.dart
@@ -159,7 +159,6 @@ class _SectionCreationPageState extends State<SectionCreationPage> {
                                   _directionsVisible = !_directionsVisible;
                                 });
                               },
-                              visibility: _directionsVisible,
                             ),
                           ],
                         ),

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -121,12 +121,12 @@ class _SectionCutterState extends State<SectionCutter> {
                 ),
               ),
               DirectionsButton(
-                  onTap: () {
-                    setState(() {
-                      _directionsVisible = !_directionsVisible;
-                    });
-                  },
-                  visibility: _directionsVisible),
+                onTap: () {
+                  setState(() {
+                    _directionsVisible = !_directionsVisible;
+                  });
+                },
+              ),
               Align(
                 alignment: Alignment.bottomLeft,
                 child: Padding(

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -747,13 +747,11 @@ class DirectionsButton extends StatelessWidget {
   const DirectionsButton({
     super.key,
     required this.onTap,
-    required this.visibility,
     this.buttonPadding,
   });
 
   final VoidCallback? onTap;
   final EdgeInsets? buttonPadding;
-  final bool visibility;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -383,45 +383,49 @@ class DialogTextBox extends StatelessWidget {
 }
 
 class TimerButtonAndDisplay extends StatelessWidget {
-  const TimerButtonAndDisplay(
-      {required this.onPressed,
-      required this.testIsRunning,
-      required this.remainingSeconds,
-      super.key});
+  const TimerButtonAndDisplay({
+    super.key,
+    required this.onPressed,
+    required this.isTestRunning,
+    required this.remainingSeconds,
+  });
 
   final VoidCallback onPressed;
-  final bool testIsRunning;
+  final bool isTestRunning;
   final int remainingSeconds;
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: <Widget>[
-      ElevatedButton(
-        style: ElevatedButton.styleFrom(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8), // Rounded rectangle shape.
+    return SizedBox(
+      width: 66,
+      child: Column(children: <Widget>[
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+            backgroundColor: isTestRunning ? Colors.red : Colors.green,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
           ),
-          backgroundColor: testIsRunning ? Colors.red : Colors.green,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          onPressed: onPressed,
+          child: Text(
+            isTestRunning ? 'End' : 'Start',
+            style: const TextStyle(color: Colors.white, fontSize: 16),
+          ),
         ),
-        onPressed: onPressed,
-        child: Text(
-          testIsRunning ? 'End' : 'Start',
-          style: const TextStyle(color: Colors.white, fontSize: 16),
+        Container(
+          padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.6),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            formatTime(remainingSeconds),
+            style: TextStyle(color: Colors.white, fontSize: 16),
+          ),
         ),
-      ),
-      Container(
-        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        decoration: BoxDecoration(
-          color: Colors.black.withValues(alpha: 0.6),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Text(
-          formatTime(remainingSeconds),
-          style: TextStyle(color: Colors.white, fontSize: 16),
-        ),
-      ),
-    ]);
+      ]),
+    );
   }
 }
 
@@ -747,11 +751,9 @@ class DirectionsButton extends StatelessWidget {
   const DirectionsButton({
     super.key,
     required this.onTap,
-    this.buttonPadding,
   });
 
   final VoidCallback? onTap;
-  final EdgeInsets? buttonPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -808,6 +810,7 @@ class DirectionsText extends StatelessWidget {
           ),
           child: Text(
             text,
+            textAlign: TextAlign.center,
             maxLines: 3,
             overflow: TextOverflow.ellipsis,
             style: TextStyle(
@@ -1010,18 +1013,21 @@ class TestErrorText extends StatelessWidget {
   /// Displays a text error at bottom of screen with the text specified by the
   /// [text] parameter. Defaults to point placed outside of polygon error text.
   const TestErrorText({
-    this.text,
     super.key,
+    this.text,
+    this.padding,
   });
 
   final String? text;
+  final EdgeInsets? padding;
 
   @override
   Widget build(BuildContext context) {
     return Align(
       alignment: Alignment.bottomCenter,
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 30.0, horizontal: 100.0),
+        padding: padding ??
+            const EdgeInsets.symmetric(vertical: 30.0, horizontal: 50.0),
         child: Container(
           padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
           decoration: BoxDecoration(


### PR DESCRIPTION
Updated layouts for the following pages in accordance with recent discussions:
- Absence of order test
- Identify access test
- Nature prevalence test
- Section creation page

Removed some unused parameters from DirectionsButton widget.
Added padding parameter to TestErrorText and changed default (also moved where this is used on the pages where layout was updated).
Wrapped TimerButtonAndDisplay in SizedBox with static width as discussed. Also renamed bool parameter to isTestRunning.