### PR TITLE
Acoustic timer backend added, implemented timer and new layout on People in Motion and Spatial Boundaries.

### DIFF
--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -246,6 +246,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                       polygons: _polygons,
                       onTap: _isDescriptionReady ? _togglePoint : null,
                       mapType: _currentMapType,
+                      myLocationButtonEnabled: false,
                     ),
                   ),
                   Row(

--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -71,7 +72,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
   Timer? _timer;
   Timer? _outsidePointTimer;
   int _remainingSeconds = -1;
-  static const double _bottomSheetHeight = 165;
+  static const double _bottomSheetHeight = 185;
 
   @override
   void initState() {
@@ -228,6 +229,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         resizeToAvoidBottomInset: false,
@@ -255,30 +257,35 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: <Widget>[
                       Padding(
-                        padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                        child: TimerButtonAndDisplay(
-                          onPressed: () {
-                            setState(() {
-                              if (_isTestRunning) {
-                                setState(() {
-                                  _isTestRunning = false;
-                                  _timer?.cancel();
-                                  _setTempData(null);
-                                });
-                              } else {
-                                _startTest();
-                              }
-                            });
-                          },
-                          isTestRunning: _isTestRunning,
-                          remainingSeconds: _remainingSeconds,
+                        padding:
+                            EdgeInsets.only(top: topOverlayPadding, left: 15.0),
+                        child: SizedBox(
+                          width: 75,
+                          child: TimerButtonAndDisplay(
+                            onPressed: () {
+                              setState(() {
+                                if (_isTestRunning) {
+                                  setState(() {
+                                    _isTestRunning = false;
+                                    _timer?.cancel();
+                                    _setTempData(null);
+                                  });
+                                } else {
+                                  _startTest();
+                                }
+                              });
+                            },
+                            isTestRunning: _isTestRunning,
+                            remainingSeconds: _remainingSeconds,
+                          ),
                         ),
                       ),
                       Expanded(
                         child: _directionsVisible
                             ? Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 15.0, vertical: 15.0),
+                                padding: EdgeInsets.symmetric(
+                                    horizontal: 15.0,
+                                    vertical: topOverlayPadding),
                                 child: DirectionsText(
                                   onTap: () {
                                     setState(() {
@@ -293,7 +300,8 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                             : SizedBox(),
                       ),
                       Padding(
-                        padding: const EdgeInsets.only(top: 15, right: 15),
+                        padding:
+                            EdgeInsets.only(top: topOverlayPadding, right: 15),
                         child: Column(
                           spacing: 10,
                           children: <Widget>[

--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -171,6 +171,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
           timer.cancel();
           showDialog(
             context: context,
+            barrierDismissible: false,
             builder: (context) {
               return TimerEndDialog(onSubmit: () {
                 Navigator.pop(context);

--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -256,7 +256,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
             ),
             SafeArea(
               child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: 15),
+                padding: const EdgeInsets.symmetric(horizontal: 15),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/absence_of_order_test.dart
+++ b/lib/absence_of_order_test.dart
@@ -56,7 +56,7 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
   bool _isLoading = true;
   bool _outsidePoint = false;
   bool _isTestRunning = false;
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
   bool _isDescriptionReady = false;
 
   late GoogleMapController mapController;
@@ -259,25 +259,22 @@ class _AbsenceOfOrderTestPageState extends State<AbsenceOfOrderTestPage> {
                       Padding(
                         padding:
                             EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                        child: SizedBox(
-                          width: 75,
-                          child: TimerButtonAndDisplay(
-                            onPressed: () {
-                              setState(() {
-                                if (_isTestRunning) {
-                                  setState(() {
-                                    _isTestRunning = false;
-                                    _timer?.cancel();
-                                    _setTempData(null);
-                                  });
-                                } else {
-                                  _startTest();
-                                }
-                              });
-                            },
-                            isTestRunning: _isTestRunning,
-                            remainingSeconds: _remainingSeconds,
-                          ),
+                        child: TimerButtonAndDisplay(
+                          onPressed: () {
+                            setState(() {
+                              if (_isTestRunning) {
+                                setState(() {
+                                  _isTestRunning = false;
+                                  _timer?.cancel();
+                                  _setTempData(null);
+                                });
+                              } else {
+                                _startTest();
+                              }
+                            });
+                          },
+                          isTestRunning: _isTestRunning,
+                          remainingSeconds: _remainingSeconds,
                         ),
                       ),
                       Expanded(

--- a/lib/acoustic_profile_test.dart
+++ b/lib/acoustic_profile_test.dart
@@ -5,32 +5,12 @@ import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:p2bp_2025spring_mobile/acoustic_instructions.dart';
+import 'package:p2bp_2025spring_mobile/assets.dart';
 import 'package:p2bp_2025spring_mobile/db_schema_classes.dart';
 import 'package:p2bp_2025spring_mobile/firestore_functions.dart';
 import 'package:p2bp_2025spring_mobile/google_maps_functions.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
 import 'package:p2bp_2025spring_mobile/widgets.dart'; // for _showInstructionOverlay
-
-/// Icon for a standing point that hasn't been measured yet
-final AssetMapBitmap _incompleteIcon = AssetMapBitmap(
-  'assets/standing_point_disabled.png',
-  width: 48,
-  height: 48,
-);
-
-/// Icon for a standing point that has completed its measurement
-final AssetMapBitmap _completeIcon = AssetMapBitmap(
-  'assets/standing_point_enabled.png',
-  width: 48,
-  height: 48,
-);
-
-/// Icon for a standing point that is actively being measured
-final AssetMapBitmap _activeIcon = AssetMapBitmap(
-  'assets/standing_point_active.png',
-  width: 48,
-  height: 48,
-);
 
 /// AcousticProfileTestPage displays a Google Map (with the project polygon)
 /// in the background and uses a timer to prompt the researcher for sound
@@ -112,7 +92,7 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
         Marker(
           markerId: markerId,
           position: point.location,
-          icon: _incompleteIcon,
+          icon: standingPointDisabledIcon,
           infoWindow: InfoWindow(
             title: point.title,
             snippet: '${point.location.latitude.toStringAsFixed(5)},'
@@ -165,26 +145,28 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
   ///
   /// This includes exchanging the marker's icon for the [_activeIcon].
   void _setActiveMarker(Marker marker) {
-    if (marker.icon == _incompleteIcon) {
+    if (marker.icon == standingPointDisabledIcon) {
       // If activeMarker already set then change icon back to incomplete.
       if (_activeMarker != null) {
-        final newMarker = _activeMarker!.copyWith(iconParam: _incompleteIcon);
+        final newMarker =
+            _activeMarker!.copyWith(iconParam: standingPointDisabledIcon);
         setState(() {
           _markers.add(newMarker);
           _markers.remove(_activeMarker);
         });
       }
       // Change selected marker icon to active icon and assign to _activeMarker.
-      final newActiveMarker = marker.copyWith(iconParam: _activeIcon);
+      final newActiveMarker =
+          marker.copyWith(iconParam: standingPointActiveIcon);
       setState(() {
         _markers.add(newActiveMarker);
         _activeMarker = newActiveMarker;
         _markers.remove(marker);
       });
-    } else if (marker.icon == _completeIcon) {
+    } else if (marker.icon == standingPointEnabledIcon) {
       print('_setActiveMarker called on complete marker');
       return;
-    } else if (marker.icon == _activeIcon) {
+    } else if (marker.icon == standingPointActiveIcon) {
       print('_setActiveMarker called on active marker');
       return;
     }
@@ -251,7 +233,8 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
       _intervalsRemaining = _intervalCount;
       _remainingSeconds = 0;
     });
-    final newMarker = _activeMarker!.copyWith(iconParam: _completeIcon);
+    final newMarker =
+        _activeMarker!.copyWith(iconParam: standingPointEnabledIcon);
     _standingPointCompletionStatus[_activeMarker!.markerId] = true;
     setState(() {
       _markers.add(newMarker);

--- a/lib/acoustic_profile_test.dart
+++ b/lib/acoustic_profile_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,7 +10,7 @@ import 'package:p2bp_2025spring_mobile/db_schema_classes.dart';
 import 'package:p2bp_2025spring_mobile/firestore_functions.dart';
 import 'package:p2bp_2025spring_mobile/google_maps_functions.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
-import 'package:p2bp_2025spring_mobile/widgets.dart'; // for _showInstructionOverlay
+import 'package:p2bp_2025spring_mobile/widgets.dart';
 
 /// AcousticProfileTestPage displays a Google Map (with the project polygon)
 /// in the background and uses a timer to prompt the researcher for sound
@@ -413,24 +412,17 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
 
   @override
   Widget build(BuildContext context) {
-    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
-    return AdaptiveSafeArea(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: (_currentMapType == MapType.normal)
+          ? SystemUiOverlayStyle.dark.copyWith(
+              statusBarColor: Colors.transparent,
+            )
+          : SystemUiOverlayStyle.light.copyWith(
+              statusBarColor: Colors.transparent,
+            ),
       child: Scaffold(
-        extendBodyBehindAppBar: true,
-        appBar: AppBar(
-          systemOverlayStyle: Platform.isIOS
-              ? (_currentMapType == MapType.normal
-                  ? SystemUiOverlayStyle.dark.copyWith(
-                      statusBarColor: Colors.transparent,
-                    )
-                  : SystemUiOverlayStyle.light.copyWith(
-                      statusBarColor: Colors.transparent,
-                    ))
-              : null,
-          backgroundColor: Colors.transparent,
-          automaticallyImplyLeading: false,
-          forceMaterialTransparency: true,
-        ),
+        resizeToAvoidBottomInset: false,
+        extendBody: true,
         body: Stack(
           children: [
             SizedBox(
@@ -448,102 +440,99 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
                 myLocationButtonEnabled: false,
               ),
             ),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: Column(
-                    spacing: 10,
-                    children: <Widget>[
-                      TimerButtonAndDisplay(
-                        onPressed:
-                            (!_isIntervalCycleRunning && _activeMarker != null)
-                                ? () {
-                                    setState(() {
-                                      if (_isIntervalCycleRunning) {
-                                        setState(() {
-                                          _isIntervalCycleRunning = false;
-                                          _timer?.cancel();
-                                        });
-                                      } else {
-                                        _startIntervalCycles();
-                                      }
-                                    });
-                                  }
-                                : null,
-                        isTestRunning: _isIntervalCycleRunning,
-                        remainingSeconds: _remainingSeconds,
-                      ),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
-                        decoration: BoxDecoration(
-                          color: Colors.black.withValues(alpha: 0.6),
-                          borderRadius: BorderRadius.circular(8),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Column(
+                      spacing: 10,
+                      children: <Widget>[
+                        TimerButtonAndDisplay(
+                          onPressed: (!_isIntervalCycleRunning &&
+                                  _activeMarker != null)
+                              ? () {
+                                  setState(() {
+                                    if (_isIntervalCycleRunning) {
+                                      setState(() {
+                                        _isIntervalCycleRunning = false;
+                                        _timer?.cancel();
+                                      });
+                                    } else {
+                                      _startIntervalCycles();
+                                    }
+                                  });
+                                }
+                              : null,
+                          isTestRunning: _isIntervalCycleRunning,
+                          remainingSeconds: _remainingSeconds,
                         ),
-                        child: Text(
-                          '${_intervalCount - _intervalsRemaining} / $_intervalCount',
-                          style: const TextStyle(
-                              color: Colors.white, fontSize: 14),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  child: _directionsVisible
-                      ? Padding(
-                          padding: EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: topOverlayPadding),
-                          child: DirectionsText(
-                            onTap: () {
-                              setState(() {
-                                _directionsVisible = !_directionsVisible;
-                              });
-                            },
-                            text: _getDirections(),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.6),
+                            borderRadius: BorderRadius.circular(8),
                           ),
-                        )
-                      : SizedBox(),
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15.0),
-                  child: Column(
-                    spacing: 10,
-                    children: <Widget>[
-                      DirectionsButton(
-                        onTap: () {
-                          setState(() {
-                            _directionsVisible = !_directionsVisible;
-                          });
-                        },
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            const Color(0xFF7EAD80).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF2D6040),
-                        onPressed: _toggleMapType,
-                        icon: Icon(
-                          Icons.layers,
-                          color: Color(0xFF2D6040),
+                          child: Text(
+                            '${_intervalCount - _intervalsRemaining} / $_intervalCount',
+                            style: const TextStyle(
+                                color: Colors.white, fontSize: 14),
+                          ),
                         ),
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            Color(0xFFBACFEB).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF37597D),
-                        onPressed: _showInstructionOverlay,
-                        icon: Icon(
-                          FontAwesomeIcons.info,
-                          color: Color(0xFF37597D),
+                      ],
+                    ),
+                    SizedBox(width: 15),
+                    Expanded(
+                      child: _directionsVisible
+                          ? DirectionsText(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
+                              text: _getDirections(),
+                            )
+                          : SizedBox(),
+                    ),
+                    SizedBox(width: 15),
+                    Column(
+                      spacing: 10,
+                      children: <Widget>[
+                        DirectionsButton(
+                          onTap: () {
+                            setState(() {
+                              _directionsVisible = !_directionsVisible;
+                            });
+                          },
                         ),
-                      ),
-                    ],
-                  ),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              const Color(0xFF7EAD80).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: Icon(
+                            Icons.layers,
+                            color: Color(0xFF2D6040),
+                          ),
+                        ),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFFBACFEB).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF37597D),
+                          onPressed: _showInstructionOverlay,
+                          icon: Icon(
+                            FontAwesomeIcons.info,
+                            color: Color(0xFF37597D),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ],
         ),

--- a/lib/acoustic_profile_test.dart
+++ b/lib/acoustic_profile_test.dart
@@ -48,8 +48,8 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
   late final List<StandingPoint> _standingPoints;
 
   Timer? _timer;
-  final int _intervalDuration = 4; // TODO replace with member of test later
-  final int _intervalCount = 3; // TODO replace with member of test later
+  int _intervalDuration = -1;
+  int _intervalCount = -1;
   int _remainingSeconds = 0;
   int _intervalsRemaining = 0;
 
@@ -62,13 +62,15 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
   @override
   void initState() {
     super.initState();
-    _intervalsRemaining = _intervalCount;
     _polygons.add(getProjectPolygon(widget.activeProject.polygonPoints));
     _location = getPolygonCentroid(_polygons.first);
     _zoom = getIdealZoom(
       _polygons.first.toMPLatLngList(),
       _location.toMPLatLng(),
     );
+    _intervalDuration = widget.activeTest.intervalDuration;
+    _intervalCount = widget.activeTest.intervalCount;
+    _intervalsRemaining = _intervalCount;
     _standingPoints = widget.activeTest.standingPoints.toList();
     // Create an AcousticDataPoint in _newData for each standing point.
     for (final point in _standingPoints) {
@@ -265,7 +267,7 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       builder: (context) {
         return Padding(
-          padding: MediaQuery.of(context).viewInsets + const EdgeInsets.all(16),
+          padding: MediaQuery.viewInsetsOf(context) + const EdgeInsets.all(16),
           child: _DecibelLevelForm(),
         );
       },
@@ -284,7 +286,7 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       builder: (context) {
         return Padding(
-          padding: MediaQuery.of(context).viewInsets + const EdgeInsets.all(16),
+          padding: MediaQuery.viewInsetsOf(context) + const EdgeInsets.all(16),
           child: _SoundTypeForm(),
         );
       },
@@ -303,7 +305,7 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       builder: (context) {
         return Padding(
-          padding: MediaQuery.of(context).viewInsets + const EdgeInsets.all(16),
+          padding: MediaQuery.viewInsetsOf(context) + const EdgeInsets.all(16),
           child: _MainSoundTypeForm(selectedSoundTypes),
         );
       },
@@ -451,24 +453,42 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
               children: <Widget>[
                 Padding(
                   padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed:
-                        (!_isIntervalCycleRunning && _activeMarker != null)
-                            ? () {
-                                setState(() {
-                                  if (_isIntervalCycleRunning) {
+                  child: Column(
+                    spacing: 10,
+                    children: <Widget>[
+                      TimerButtonAndDisplay(
+                        onPressed:
+                            (!_isIntervalCycleRunning && _activeMarker != null)
+                                ? () {
                                     setState(() {
-                                      _isIntervalCycleRunning = false;
-                                      _timer?.cancel();
+                                      if (_isIntervalCycleRunning) {
+                                        setState(() {
+                                          _isIntervalCycleRunning = false;
+                                          _timer?.cancel();
+                                        });
+                                      } else {
+                                        _startIntervalCycles();
+                                      }
                                     });
-                                  } else {
-                                    _startIntervalCycles();
                                   }
-                                });
-                              }
-                            : null,
-                    isTestRunning: _isIntervalCycleRunning,
-                    remainingSeconds: _remainingSeconds,
+                                : null,
+                        isTestRunning: _isIntervalCycleRunning,
+                        remainingSeconds: _remainingSeconds,
+                      ),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 8),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.6),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          '${_intervalCount - _intervalsRemaining} / $_intervalCount',
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 14),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
                 Expanded(

--- a/lib/acoustic_profile_test.dart
+++ b/lib/acoustic_profile_test.dart
@@ -413,6 +413,7 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
@@ -452,28 +453,31 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
+                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
                   child: Column(
                     spacing: 10,
                     children: <Widget>[
-                      TimerButtonAndDisplay(
-                        onPressed:
-                            (!_isIntervalCycleRunning && _activeMarker != null)
-                                ? () {
-                                    setState(() {
-                                      if (_isIntervalCycleRunning) {
-                                        setState(() {
-                                          _isIntervalCycleRunning = false;
-                                          _timer?.cancel();
-                                        });
-                                      } else {
-                                        _startIntervalCycles();
-                                      }
-                                    });
-                                  }
-                                : null,
-                        isTestRunning: _isIntervalCycleRunning,
-                        remainingSeconds: _remainingSeconds,
+                      SizedBox(
+                        width: 75,
+                        child: TimerButtonAndDisplay(
+                          onPressed: (!_isIntervalCycleRunning &&
+                                  _activeMarker != null)
+                              ? () {
+                                  setState(() {
+                                    if (_isIntervalCycleRunning) {
+                                      setState(() {
+                                        _isIntervalCycleRunning = false;
+                                        _timer?.cancel();
+                                      });
+                                    } else {
+                                      _startIntervalCycles();
+                                    }
+                                  });
+                                }
+                              : null,
+                          isTestRunning: _isIntervalCycleRunning,
+                          remainingSeconds: _remainingSeconds,
+                        ),
                       ),
                       Container(
                         padding: const EdgeInsets.symmetric(
@@ -494,8 +498,8 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
                 Expanded(
                   child: _directionsVisible
                       ? Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: 15.0),
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: topOverlayPadding),
                           child: DirectionsText(
                             onTap: () {
                               setState(() {
@@ -508,7 +512,7 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
                       : SizedBox(),
                 ),
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, right: 15.0),
+                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15.0),
                   child: Column(
                     spacing: 10,
                     children: <Widget>[

--- a/lib/acoustic_profile_test.dart
+++ b/lib/acoustic_profile_test.dart
@@ -457,27 +457,24 @@ class _AcousticProfileTestPageState extends State<AcousticProfileTestPage> {
                   child: Column(
                     spacing: 10,
                     children: <Widget>[
-                      SizedBox(
-                        width: 75,
-                        child: TimerButtonAndDisplay(
-                          onPressed: (!_isIntervalCycleRunning &&
-                                  _activeMarker != null)
-                              ? () {
-                                  setState(() {
-                                    if (_isIntervalCycleRunning) {
-                                      setState(() {
-                                        _isIntervalCycleRunning = false;
-                                        _timer?.cancel();
-                                      });
-                                    } else {
-                                      _startIntervalCycles();
-                                    }
-                                  });
-                                }
-                              : null,
-                          isTestRunning: _isIntervalCycleRunning,
-                          remainingSeconds: _remainingSeconds,
-                        ),
+                      TimerButtonAndDisplay(
+                        onPressed:
+                            (!_isIntervalCycleRunning && _activeMarker != null)
+                                ? () {
+                                    setState(() {
+                                      if (_isIntervalCycleRunning) {
+                                        setState(() {
+                                          _isIntervalCycleRunning = false;
+                                          _timer?.cancel();
+                                        });
+                                      } else {
+                                        _startIntervalCycles();
+                                      }
+                                    });
+                                  }
+                                : null,
+                        isTestRunning: _isIntervalCycleRunning,
+                        remainingSeconds: _remainingSeconds,
                       ),
                       Container(
                         padding: const EdgeInsets.symmetric(

--- a/lib/assets.dart
+++ b/lib/assets.dart
@@ -2,6 +2,11 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'db_schema_classes.dart';
 
+final AssetMapBitmap tempMarkerIcon = AssetMapBitmap(
+  'assets/temp_point_marker.png',
+  width: 40,
+  height: 40,
+);
 final AssetMapBitmap standingPointDisabledIcon = AssetMapBitmap(
   'assets/standing_point_disabled.png',
   width: 48,

--- a/lib/assets.dart
+++ b/lib/assets.dart
@@ -1,5 +1,7 @@
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
+import 'db_schema_classes.dart';
+
 final AssetMapBitmap standingPointDisabledIcon = AssetMapBitmap(
   'assets/standing_point_disabled.png',
   width: 48,
@@ -75,28 +77,7 @@ final AssetMapBitmap squattingNAMarker = AssetMapBitmap(
   width: 36,
   height: 36,
 );
-final AssetMapBitmap walkingConnector = AssetMapBitmap(
-  'assets/test_specific/people_in_motion/square_marker_teal.png',
-  width: 24,
-  height: 24,
-);
-final AssetMapBitmap runningConnector = AssetMapBitmap(
-  'assets/test_specific/people_in_motion/square_marker_red.png',
-  width: 24,
-  height: 24,
-);
-final AssetMapBitmap swimmingConnector = AssetMapBitmap(
-  'assets/test_specific/people_in_motion/square_marker_cyan.png',
-  width: 24,
-  height: 24,
-);
-final AssetMapBitmap wheelsConnector = AssetMapBitmap(
-  'assets/test_specific/people_in_motion/square_marker_orange.png',
-  width: 24,
-  height: 24,
-);
-final AssetMapBitmap handicapConnector = AssetMapBitmap(
-  'assets/test_specific/people_in_motion/square_marker_purple.png',
-  width: 24,
-  height: 24,
-);
+final Map<ActivityTypeInMotion, AssetMapBitmap> activityInMotionIconMap = {
+  for (final value in ActivityTypeInMotion.values)
+    value: AssetMapBitmap(value.iconName, width: 24, height: 24)
+};

--- a/lib/assets.dart
+++ b/lib/assets.dart
@@ -17,67 +17,17 @@ final AssetMapBitmap standingPointActiveIcon = AssetMapBitmap(
   width: 48,
   height: 48,
 );
-final AssetMapBitmap standingMaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/standing_male_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap sittingMaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/sitting_male_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap layingMaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/laying_male_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap squattingMaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/squatting_male_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap standingFemaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/standing_female_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap sittingFemaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/sitting_female_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap layingFemaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/laying_female_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap squattingFemaleMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/squatting_female_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap standingNAMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/standing_na_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap sittingNAMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/sitting_na_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap layingNAMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/laying_na_marker.png',
-  width: 36,
-  height: 36,
-);
-final AssetMapBitmap squattingNAMarker = AssetMapBitmap(
-  'assets/test_specific/people_in_place/squatting_na_marker.png',
-  width: 36,
-  height: 36,
-);
-final Map<ActivityTypeInMotion, AssetMapBitmap> activityInMotionIconMap = {
+final Map<(PostureType, GenderType), AssetMapBitmap> peopleInPlaceIconMap = {
+  for (final posture in PostureType.values)
+    for (final gender in GenderType.values)
+      (posture, gender): AssetMapBitmap(
+        'assets/test_specific/people_in_place/'
+        '${posture.iconNameSegment}_${gender.iconNameSegment}_marker.png',
+        width: 36,
+        height: 36,
+      )
+};
+final Map<ActivityTypeInMotion, AssetMapBitmap> peopleInMotionIconMap = {
   for (final value in ActivityTypeInMotion.values)
     value: AssetMapBitmap(value.iconName, width: 24, height: 24)
 };

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -1,22 +1,23 @@
 import 'dart:io';
 import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:file_selector/file_selector.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:maps_toolkit/maps_toolkit.dart' as mp;
 import 'package:p2bp_2025spring_mobile/absence_of_order_test.dart';
+import 'package:p2bp_2025spring_mobile/acoustic_profile_test.dart';
 import 'package:p2bp_2025spring_mobile/google_maps_functions.dart';
 import 'package:p2bp_2025spring_mobile/lighting_profile_test.dart';
-import 'package:p2bp_2025spring_mobile/section_cutter_test.dart';
-import 'package:p2bp_2025spring_mobile/people_in_place_test.dart';
 import 'package:p2bp_2025spring_mobile/people_in_motion_test.dart';
-import 'package:p2bp_2025spring_mobile/acoustic_profile_test.dart';
+import 'package:p2bp_2025spring_mobile/people_in_place_test.dart';
+import 'package:p2bp_2025spring_mobile/section_cutter_test.dart';
 import 'package:p2bp_2025spring_mobile/spatial_boundaries_test.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
-import 'firestore_functions.dart';
-import 'package:flutter/material.dart';
-import 'package:firebase_storage/firebase_storage.dart';
-import 'package:maps_toolkit/maps_toolkit.dart' as mp;
 
+import 'firestore_functions.dart';
 import 'identifying_access_test.dart';
 import 'nature_prevalence_test.dart';
 
@@ -2483,7 +2484,6 @@ enum AgeRangeType implements DisplayNameEnum {
 enum GenderType implements DisplayNameEnum {
   male(displayName: 'Male'),
   female(displayName: 'Female'),
-  nonbinary(displayName: 'Nonbinary'),
   unspecified(displayName: 'Unspecified');
 
   const GenderType({required this.displayName});
@@ -2751,21 +2751,42 @@ class PeopleInPlaceTest extends Test<PeopleInPlaceData>
 }
 
 enum ActivityTypeInMotion implements DisplayNameEnum {
-  walking(displayName: 'Walking', color: Colors.teal),
-  running(displayName: 'Running', color: Colors.red),
-  swimming(displayName: 'Swimming', color: Colors.cyan),
-  activityOnWheels(displayName: 'Activity on Wheels', color: Colors.orange),
+  walking(
+    displayName: 'Walking',
+    color: Colors.teal,
+    iconName: 'assets/test_specific/people_in_motion/square_marker_teal.png',
+  ),
+  running(
+    displayName: 'Running',
+    color: Colors.red,
+    iconName: 'assets/test_specific/people_in_motion/square_marker_red.png',
+  ),
+  swimming(
+    displayName: 'Swimming',
+    color: Colors.cyan,
+    iconName: 'assets/test_specific/people_in_motion/square_marker_cyan.png',
+  ),
+  activityOnWheels(
+    displayName: 'Activity on Wheels',
+    color: Colors.orange,
+    iconName: 'assets/test_specific/people_in_motion/square_marker_orange.png',
+  ),
   handicapAssistedWheels(
-      displayName: 'Handicap Assisted Wheels', color: Colors.purple);
+    displayName: 'Handicap Assisted Wheels',
+    color: Colors.purple,
+    iconName: 'assets/test_specific/people_in_motion/square_marker_purple.png',
+  );
 
   const ActivityTypeInMotion({
     required this.displayName,
     required this.color,
+    required this.iconName,
   });
 
   @override
   final String displayName;
   final Color color;
+  final String iconName;
 
   factory ActivityTypeInMotion.byDisplayName(String displayName) {
     try {

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -2482,14 +2482,18 @@ enum AgeRangeType implements DisplayNameEnum {
 }
 
 enum GenderType implements DisplayNameEnum {
-  male(displayName: 'Male'),
-  female(displayName: 'Female'),
-  unspecified(displayName: 'Unspecified');
+  male(displayName: 'Male', iconNameSegment: 'male'),
+  female(displayName: 'Female', iconNameSegment: 'female'),
+  unspecified(displayName: 'Unspecified', iconNameSegment: 'na');
 
-  const GenderType({required this.displayName});
+  const GenderType({
+    required this.displayName,
+    required this.iconNameSegment,
+  });
 
   @override
   final String displayName;
+  final String iconNameSegment;
 
   /// Returns the enumerated type with the matching displayName.
   factory GenderType.byDisplayName(String displayName) {
@@ -2530,16 +2534,37 @@ enum ActivityTypeInPlace implements DisplayNameEnum {
 }
 
 enum PostureType implements DisplayNameEnum {
-  standing(displayName: 'Standing', color: Color(0xFF4285f4)),
-  sitting(displayName: 'Sitting', color: Color(0xFF28a745)),
-  layingDown(displayName: 'Laying Down', color: Color(0xFFc41484)),
-  squatting(displayName: 'Squatting', color: Color(0xFF6f42c1));
+  standing(
+    displayName: 'Standing',
+    color: Color(0xFF4285f4),
+    iconNameSegment: 'standing',
+  ),
+  sitting(
+    displayName: 'Sitting',
+    color: Color(0xFF28a745),
+    iconNameSegment: 'sitting',
+  ),
+  layingDown(
+    displayName: 'Laying Down',
+    color: Color(0xFFc41484),
+    iconNameSegment: 'laying',
+  ),
+  squatting(
+    displayName: 'Squatting',
+    color: Color(0xFF6f42c1),
+    iconNameSegment: 'squatting',
+  );
 
-  const PostureType({required this.displayName, required this.color});
+  const PostureType({
+    required this.displayName,
+    required this.color,
+    required this.iconNameSegment,
+  });
 
   @override
   final String displayName;
   final Color color;
+  final String iconNameSegment;
 
   /// Returns the enumerated type with the matching displayName.
   factory PostureType.byDisplayName(String displayName) {

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -2054,12 +2054,12 @@ class NatureData implements NatureTypes {
 
 /// Types of weather for Nature Prevalence. Types include [sunny], [cloudy],
 /// [rainy], [windy], and [stormy].
-enum Weather { sunny, cloudy, rainy, windy, stormy }
+enum WeatherType { sunny, cloudy, rainy, windy, stormy }
 
 /// Class for weather in Nature Prevalence Test. Implements enum type
 /// [weather].
 class WeatherData implements NatureTypes {
-  final List<Weather> weatherTypes;
+  final List<WeatherType> weatherTypes; // TODO make this a set?
   final double temp;
 
   WeatherData({required this.weatherTypes, required this.temp});
@@ -2070,7 +2070,7 @@ class WeatherData implements NatureTypes {
     Map<String, bool> weatherMap = {};
     try {
       // Initialize a map for Firestore with true or false depending on weather.
-      for (Weather weatherType in Weather.values) {
+      for (WeatherType weatherType in WeatherType.values) {
         weatherTypes.contains(weatherType)
             ? weatherMap[weatherType.name] = true
             : weatherMap[weatherType.name] = false;
@@ -2355,11 +2355,11 @@ class NaturePrevalenceTest extends Test<NatureData> implements TimerTest {
     List<WaterBody> waterBodyList = [];
     List<Vegetation> vegetationList = [];
     WeatherData? weatherData;
-    List<Weather> weatherTypes = [];
+    List<WeatherType> weatherTypes = [];
 
     try {
       if (data.containsKey('weather')) {
-        for (Weather weatherType in Weather.values) {
+        for (WeatherType weatherType in WeatherType.values) {
           if (data['weather'].containsKey(weatherType) &&
               data['weather'][weatherType] == true) {
             weatherTypes.add(weatherType);

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -431,9 +431,20 @@ extension StandingPointListHelpers on List<StandingPoint> {
 ///
 /// Using this also requires that the class run
 /// [Test._standingPointTestCollectionIDs.add(collectionIDStatic)]
-/// in its register method so that it can be recognized as such.
+/// in its register method to be recognized as using standing points.
 abstract interface class StandingPointTest {
   final List<StandingPoint> standingPoints = [];
+}
+
+/// Class to be implemented by all Test subclasses which use a timer.
+///
+/// Using this also requires that the class run
+/// [Test._timerTestCollectionIDs.add(collectionIDStatic)]
+/// in its register method to be recognized as using a timer.
+abstract interface class TimerTest {
+  final int testDuration;
+
+  TimerTest(this.testDuration);
 }
 
 /// Mixin to add toString functionality to any class with a toJson() method.
@@ -498,10 +509,13 @@ class LightingProfileData with JsonToString {
 }
 
 /// Class for Lighting Profile Test info and methods.
-class LightingProfileTest extends Test<LightingProfileData> with JsonToString {
+class LightingProfileTest extends Test<LightingProfileData>
+    with JsonToString
+    implements TimerTest {
   /// Static constant definition of collection ID for this test type.
   static const String collectionIDStatic = 'lighting_profile_tests';
 
+  @override
   final int testDuration;
 
   /// Creates a new [LightingProfileTest] instance from the given arguments.
@@ -850,9 +864,12 @@ class AbsenceOfOrderData with JsonToString {
 }
 
 /// Class for Absence of Order Test info and methods.
-class AbsenceOfOrderTest extends Test<AbsenceOfOrderData> with JsonToString {
+class AbsenceOfOrderTest extends Test<AbsenceOfOrderData>
+    with JsonToString
+    implements TimerTest {
   static const String collectionIDStatic = 'absence_of_order_tests';
 
+  @override
   final int testDuration;
 
   /// Creates a new [AbsenceOfOrderTest] instance from the given arguments.
@@ -1204,9 +1221,11 @@ class SpatialBoundariesData with JsonToString {
 }
 
 class SpatialBoundariesTest extends Test<SpatialBoundariesData>
-    with JsonToString {
+    with JsonToString
+    implements TimerTest {
   static const String collectionIDStatic = 'spatial_boundaries_tests';
 
+  @override
   final int testDuration;
 
   SpatialBoundariesTest._({
@@ -1266,6 +1285,7 @@ class SpatialBoundariesTest extends Test<SpatialBoundariesData>
       await testRef.set(test as SpatialBoundariesTest, SetOptions(merge: true));
     };
     Test._testInitialsMap[SpatialBoundariesTest] = 'SB';
+    Test._timerTestCollectionIDs.add(collectionIDStatic);
   }
 
   @override
@@ -2175,7 +2195,7 @@ class Animal implements NatureTypes {
 }
 
 /// Class for Nature Prevalence test info and methods.
-class NaturePrevalenceTest extends Test<NatureData> {
+class NaturePrevalenceTest extends Test<NatureData> implements TimerTest {
   /// Returns a new instance of the initial data structure used for
   /// Nature Prevalence Test.
   static NatureData newInitialDataDeepCopy() {
@@ -2186,6 +2206,7 @@ class NaturePrevalenceTest extends Test<NatureData> {
   static const String collectionIDStatic = 'nature_prevalence_tests';
 
   /// User defined test timer duration in seconds.
+  @override
   final int testDuration;
 
   /// Creates a new [NaturePrevalenceTest] instance from the given arguments.
@@ -2261,8 +2282,8 @@ class NaturePrevalenceTest extends Test<NatureData> {
         'testDuration': (test as NaturePrevalenceTest).testDuration,
       }, SetOptions(merge: true));
     };
-    Test._timerTestCollectionIDs.add(collectionIDStatic);
     Test._testInitialsMap[NaturePrevalenceTest] = 'NP';
+    Test._timerTestCollectionIDs.add(collectionIDStatic);
   }
 
   @override
@@ -2658,11 +2679,12 @@ class PeopleInPlaceData with JsonToString {
 
 class PeopleInPlaceTest extends Test<PeopleInPlaceData>
     with JsonToString
-    implements StandingPointTest {
+    implements StandingPointTest, TimerTest {
   static const String collectionIDStatic = 'people_in_place_tests';
 
   @override
   final List<StandingPoint> standingPoints;
+  @override
   final int testDuration;
 
   PeopleInPlaceTest._({
@@ -2886,7 +2908,7 @@ class PeopleInMotionData with JsonToString {
 
 class PeopleInMotionTest extends Test<PeopleInMotionData>
     with JsonToString
-    implements StandingPointTest {
+    implements StandingPointTest, TimerTest {
   /// Static constant definition of collection ID for this test type.
   static const String collectionIDStatic = 'people_in_motion_tests';
 
@@ -2894,6 +2916,7 @@ class PeopleInMotionTest extends Test<PeopleInMotionData>
   final List<StandingPoint> standingPoints;
 
   /// User defined test timer duration in seconds.
+  @override
   final int testDuration;
 
   /// Private constructor for PeopleInMotionTest.

--- a/lib/firestore_functions.dart
+++ b/lib/firestore_functions.dart
@@ -431,8 +431,10 @@ Future<Test> saveTest({
   required String collectionID,
   List? standingPoints,
   int? testDuration,
+  int? intervalDuration,
+  int? intervalCount,
 }) async {
-  late Test tempTest;
+  late final Test tempTest;
 
   try {
     if (projectRef == null) {
@@ -451,6 +453,8 @@ Future<Test> saveTest({
       collectionID: collectionID,
       standingPoints: standingPoints,
       testDuration: testDuration,
+      intervalDuration: intervalDuration,
+      intervalCount: intervalCount,
     );
 
     await tempTest.saveToFirestore();

--- a/lib/google_maps_functions.dart
+++ b/lib/google_maps_functions.dart
@@ -249,5 +249,5 @@ String formatTime(int time) {
 /// found here: https://stackoverflow.com/a/46764320.
 double getIdealZoom(List<mp.LatLng> points, mp.LatLng centroid) {
   final maxDistanceInMeters = getMaxDistanceFromCentroid(points, centroid);
-  return (log(40000000.0 / maxDistanceInMeters) / log(2)) - 0.3;
+  return (log(40000000.0 / maxDistanceInMeters) / log(2)) - 0.6;
 }

--- a/lib/google_maps_functions.dart
+++ b/lib/google_maps_functions.dart
@@ -58,7 +58,10 @@ Future<LocationPermission> _checkLocationPermissions() async {
 /// widget.
 /// Takes an optional onTap parameter.
 Set<Polygon> finalizePolygon(List<LatLng> polygonPoints,
-    {Color? polygonColor, VoidCallback? onTap, bool? consumeTapEvents}) {
+    {Color? strokeColor,
+    Color? fillColor,
+    VoidCallback? onTap,
+    bool? consumeTapEvents}) {
   Set<Polygon> polygon = {};
   List<LatLng> polygonPointsCopy = polygonPoints.toList();
   try {
@@ -74,9 +77,10 @@ Set<Polygon> finalizePolygon(List<LatLng> polygonPoints,
         onTap: onTap,
         polygonId: PolygonId(polygonId),
         points: sortedPoints,
-        strokeColor: polygonColor ?? Colors.blue,
+        strokeColor: strokeColor ?? Colors.blue,
         strokeWidth: 2,
-        fillColor: polygonColor ?? Colors.blue.withValues(alpha: 0.2),
+        fillColor:
+            fillColor ?? strokeColor ?? Colors.blue.withValues(alpha: 0.2),
       ),
     };
   } catch (e, stacktrace) {

--- a/lib/google_maps_functions.dart
+++ b/lib/google_maps_functions.dart
@@ -245,5 +245,5 @@ String formatTime(int time) {
 /// found here: https://stackoverflow.com/a/46764320.
 double getIdealZoom(List<mp.LatLng> points, mp.LatLng centroid) {
   final maxDistanceInMeters = getMaxDistanceFromCentroid(points, centroid);
-  return (log(20000000.0 / maxDistanceInMeters) / log(2));
+  return (log(40000000.0 / maxDistanceInMeters) / log(2)) - 0.3;
 }

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -283,7 +285,8 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
+    return AdaptiveSafeArea(
       child: Scaffold(
         extendBody: true,
         resizeToAvoidBottomInset: false,
@@ -322,8 +325,9 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                       Expanded(
                         child: _directionsVisible
                             ? Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 15.0, vertical: 15.0),
+                                padding: EdgeInsets.symmetric(
+                                    horizontal: 15.0,
+                                    vertical: topOverlayPadding),
                                 child: DirectionsText(
                                     onTap: () {
                                       setState(() {
@@ -336,7 +340,8 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                             : SizedBox(),
                       ),
                       Padding(
-                        padding: const EdgeInsets.only(top: 15.0, right: 15.0),
+                        padding: EdgeInsets.only(
+                            top: topOverlayPadding, right: 15.0),
                         child: Column(
                           spacing: 10,
                           children: [

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -46,7 +46,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
 
   final AccessData _accessData = AccessData();
 
-  Set<Polygon> _projectArea = {};
+  late final Polygon _projectPolygon;
   Polyline? _currentPolyline;
   List<LatLng> _currentPolylinePoints = [];
   final Set<Polyline> _polylines = {};
@@ -65,10 +65,10 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   @override
   void initState() {
     super.initState();
-    _polygons.add(getProjectPolygon(widget.activeProject.polygonPoints));
-    _location = getPolygonCentroid(_polygons.first);
+    _projectPolygon = getProjectPolygon(widget.activeProject.polygonPoints);
+    _location = getPolygonCentroid(_projectPolygon);
     _zoom = getIdealZoom(
-      _polygons.first.toMPLatLngList(),
+      _projectPolygon.toMPLatLngList(),
       _location.toMPLatLng(),
     );
     _isLoading = false;
@@ -304,8 +304,8 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
                       initialCameraPosition:
                           CameraPosition(target: _location, zoom: _zoom),
                       polygons: _oldPolylinesToggle
-                          ? {..._projectArea, ..._polygons, ..._currentPolygon}
-                          : {..._projectArea, ..._currentPolygon},
+                          ? {_projectPolygon, ..._polygons, ..._currentPolygon}
+                          : {_projectPolygon, ..._currentPolygon},
                       markers: {
                         ..._markers,
                         ..._polygonMarkers,

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -59,7 +59,7 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   final Set<Polygon> _polygons = {}; // Set of polygons
   final Set<Marker> _markers = {}; // Set of markers for points
   Set<Marker> _polygonMarkers = {}; // Set of markers for polygon creation
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
   MapType _currentMapType = MapType.satellite; // Default map type
 
   Project? project;

--- a/lib/identifying_access_test.dart
+++ b/lib/identifying_access_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -7,10 +5,11 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:p2bp_2025spring_mobile/firestore_functions.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
 import 'package:p2bp_2025spring_mobile/widgets.dart';
-import 'project_details_page.dart';
+
 import 'db_schema_classes.dart';
 import 'google_maps_functions.dart';
 import 'home_screen.dart';
+import 'project_details_page.dart';
 
 class IdentifyingAccess extends StatefulWidget {
   final Project activeProject;
@@ -30,7 +29,6 @@ class IdentifyingAccess extends StatefulWidget {
 }
 
 class _IdentifyingAccessState extends State<IdentifyingAccess> {
-  bool _isLoading = true;
   bool _polygonMode = false;
   bool _pointMode = false;
   bool _polylineMode = false;
@@ -40,10 +38,10 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   bool _deleteMode = false;
   AccessType? _type;
   String _directions = "Choose a category.";
-  final double _bottomSheetHeight = 300;
+  static const double _bottomSheetHeight = 315;
   late DocumentReference teamRef;
   late GoogleMapController mapController;
-  LatLng _location = defaultLocation; // Default location
+  LatLng _location = defaultLocation;
   double _zoom = 18;
 
   final AccessData _accessData = AccessData();
@@ -55,12 +53,12 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
   Set<Marker> _polylineMarkers = {};
   Set<Marker> _visiblePolylineMarkers = {};
   Set<Polygon> _currentPolygon = {};
-  List<LatLng> _polygonPoints = []; // Points for the polygon
-  final Set<Polygon> _polygons = {}; // Set of polygons
-  final Set<Marker> _markers = {}; // Set of markers for points
-  Set<Marker> _polygonMarkers = {}; // Set of markers for polygon creation
+  List<LatLng> _polygonPoints = [];
+  final Set<Polygon> _polygons = {};
+  final Set<Marker> _markers = {};
+  Set<Marker> _polygonMarkers = {};
   bool _directionsVisible = true;
-  MapType _currentMapType = MapType.satellite; // Default map type
+  MapType _currentMapType = MapType.satellite;
 
   Project? project;
 
@@ -70,10 +68,10 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
     _projectPolygon = getProjectPolygon(widget.activeProject.polygonPoints);
     _location = getPolygonCentroid(_projectPolygon);
     _zoom = getIdealZoom(
-      _projectPolygon.toMPLatLngList(),
-      _location.toMPLatLng(),
-    );
-    _isLoading = false;
+          _projectPolygon.toMPLatLngList(),
+          _location.toMPLatLng(),
+        ) -
+        0.1;
   }
 
   void _onMapCreated(GoogleMapController controller) {
@@ -285,393 +283,381 @@ class _IdentifyingAccessState extends State<IdentifyingAccess> {
 
   @override
   Widget build(BuildContext context) {
-    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
-    return AdaptiveSafeArea(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: (_currentMapType == MapType.normal)
+          ? SystemUiOverlayStyle.dark.copyWith(
+              statusBarColor: Colors.transparent,
+            )
+          : SystemUiOverlayStyle.light.copyWith(
+              statusBarColor: Colors.transparent,
+            ),
       child: Scaffold(
         extendBody: true,
         resizeToAvoidBottomInset: false,
-        body: _isLoading
-            ? const Center(child: CircularProgressIndicator())
-            : Stack(
-                children: [
-                  SizedBox(
-                    height: MediaQuery.sizeOf(context).height,
-                    child: GoogleMap(
-                      polylines: _currentPolyline == null
-                          ? (_oldPolylinesToggle ? _polylines : {})
-                          : (_oldPolylinesToggle
-                              ? {..._polylines, _currentPolyline!}
-                              : {_currentPolyline!}),
-                      padding: EdgeInsets.only(bottom: _bottomSheetHeight),
-                      onMapCreated: _onMapCreated,
-                      initialCameraPosition:
-                          CameraPosition(target: _location, zoom: _zoom),
-                      polygons: _oldPolylinesToggle
-                          ? {_projectPolygon, ..._polygons, ..._currentPolygon}
-                          : {_projectPolygon, ..._currentPolygon},
-                      markers: {
-                        ..._markers,
-                        ..._polygonMarkers,
-                        ..._visiblePolylineMarkers
-                      },
-                      onTap: _togglePoint,
-                      mapType: _currentMapType, // Use current map type
-                    ),
-                  ),
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Expanded(
-                        child: _directionsVisible
-                            ? Padding(
-                                padding: EdgeInsets.symmetric(
-                                    horizontal: 15.0,
-                                    vertical: topOverlayPadding),
-                                child: DirectionsText(
-                                    onTap: () {
-                                      setState(() {
-                                        _directionsVisible =
-                                            !_directionsVisible;
-                                      });
-                                    },
-                                    text: _directions),
-                              )
-                            : SizedBox(),
-                      ),
-                      Padding(
-                        padding: EdgeInsets.only(
-                            top: topOverlayPadding, right: 15.0),
-                        child: Column(
-                          spacing: 10,
-                          children: [
-                            DirectionsButton(
+        body: Stack(
+          children: [
+            SizedBox(
+              height: MediaQuery.sizeOf(context).height,
+              child: GoogleMap(
+                polylines: _currentPolyline == null
+                    ? (_oldPolylinesToggle ? _polylines : {})
+                    : (_oldPolylinesToggle
+                        ? {..._polylines, _currentPolyline!}
+                        : {_currentPolyline!}),
+                padding: EdgeInsets.only(bottom: _bottomSheetHeight),
+                onMapCreated: _onMapCreated,
+                initialCameraPosition:
+                    CameraPosition(target: _location, zoom: _zoom),
+                polygons: _oldPolylinesToggle
+                    ? {_projectPolygon, ..._polygons, ..._currentPolygon}
+                    : {_projectPolygon, ..._currentPolygon},
+                markers: {
+                  ..._markers,
+                  ..._polygonMarkers,
+                  ..._visiblePolylineMarkers
+                },
+                onTap: _togglePoint,
+                mapType: _currentMapType,
+                myLocationButtonEnabled: false,
+              ),
+            ),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Expanded(
+                      child: _directionsVisible
+                          ? DirectionsText(
                               onTap: () {
                                 setState(() {
                                   _directionsVisible = !_directionsVisible;
                                 });
                               },
-                            ),
-                            CircularIconMapButton(
-                              backgroundColor: Colors.green,
-                              borderColor: Color(0xFF2D6040),
-                              onPressed: _toggleMapType,
-                              icon: const Icon(Icons.map),
-                            ),
-                            if (!_polygonMode && !_pointMode && !_polylineMode)
-                              CircularIconMapButton(
-                                borderColor: Color(0xFF2D6040),
-                                onPressed: () {
-                                  setState(() {
-                                    _deleteMode = !_deleteMode;
-                                  });
-                                },
-                                backgroundColor:
-                                    _deleteMode ? Colors.blue : Colors.red,
-                                icon: Icon(
-                                  _deleteMode
-                                      ? Icons.location_on
-                                      : Icons.delete,
-                                  size: 30,
-                                ),
-                              ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                  Align(
-                    alignment: Alignment.bottomLeft,
-                    child: Padding(
-                      padding: EdgeInsets.only(
-                          bottom: _bottomSheetHeight + 35, left: 5),
-                      child: VisibilitySwitch(
-                        visibility: _oldPolylinesToggle,
-                        onChanged: (value) {
-                          // This is called when the user toggles the switch.
-                          setState(() {
-                            _oldPolylinesToggle = value;
-                          });
-                        },
-                      ),
+                              text: _directions)
+                          : SizedBox(),
                     ),
-                  ),
-                  if (_deleteMode)
-                    TestErrorText(
-                      padding: EdgeInsets.fromLTRB(
-                          20, 0, 20, _bottomSheetHeight + 30),
-                      text: "You are in delete mode.",
-                    ),
-                ],
-              ),
-        bottomSheet: _isLoading
-            ? SizedBox()
-            : SizedBox(
-                height: _bottomSheetHeight,
-                child: Stack(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0, vertical: 10.0),
-                      decoration: BoxDecoration(
-                        gradient: defaultGrad,
-                        borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(24.0),
-                          topRight: Radius.circular(24.0),
+                    SizedBox(width: 15),
+                    Column(
+                      spacing: 10,
+                      children: [
+                        DirectionsButton(
+                          onTap: () {
+                            setState(() {
+                              _directionsVisible = !_directionsVisible;
+                            });
+                          },
                         ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black,
-                            offset: Offset(0.0, 1.0), //(x,y)
-                            blurRadius: 6.0,
-                          ),
-                        ],
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          SizedBox(height: 5),
-                          Center(
-                            child: Text(
-                              'Identifying Access',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: placeYellow,
-                              ),
+                        CircularIconMapButton(
+                          backgroundColor: Colors.green,
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: const Icon(Icons.map),
+                        ),
+                        if (!_polygonMode && !_pointMode && !_polylineMode)
+                          CircularIconMapButton(
+                            borderColor: Color(0xFF2D6040),
+                            onPressed: () {
+                              setState(() {
+                                _deleteMode = !_deleteMode;
+                              });
+                            },
+                            backgroundColor:
+                                _deleteMode ? Colors.blue : Colors.red,
+                            icon: Icon(
+                              _deleteMode ? Icons.location_on : Icons.delete,
+                              size: 30,
                             ),
                           ),
-                          Align(
-                            alignment: Alignment.topCenter,
-                            child: Text(
-                              'Mark where people enter the project area from.',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontStyle: FontStyle.italic,
-                                color: Colors.grey[400],
-                              ),
-                            ),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFFE4E9EF).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF4A5D75),
+                          onPressed: () {
+                            setState(() {
+                              _oldPolylinesToggle = !_oldPolylinesToggle;
+                            });
+                          },
+                          icon: Icon(
+                            _oldPolylinesToggle
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                            size: 30,
+                            color: Color(0xFF4A5D75),
                           ),
-                          SizedBox(height: 15),
-                          Center(
-                            child: Text(
-                              'Access Type',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                          SizedBox(height: 5),
-                          Row(
-                            spacing: 10,
-                            children: <Widget>[
-                              TestButton(
-                                flex: 6,
-                                buttonText: 'Parking',
-                                onPressed: (_pointMode ||
-                                        _polygonMode ||
-                                        _polylineMode ||
-                                        _deleteMode)
-                                    ? null
-                                    : () {
-                                        setState(() {
-                                          _type = AccessType.parking;
-                                          _polygonMode = true;
-                                          _directions =
-                                              'First, define the parking area by creating a polygon.';
-                                        });
-                                      },
-                              ),
-                              TestButton(
-                                flex: 6,
-                                buttonText: 'Public Transport',
-                                onPressed: (_pointMode ||
-                                        _polygonMode ||
-                                        _polylineMode ||
-                                        _deleteMode)
-                                    ? null
-                                    : () {
-                                        _showInputDialog(
-                                          text: 'Enter the Route Number',
-                                          hintText: 'Route Number',
-                                          onNext: () {
-                                            setState(() {
-                                              _type =
-                                                  AccessType.transportStation;
-                                              _polylineMode = true;
-                                              _directions =
-                                                  "Mark the spot of the transport station. Then define the path to the project area.";
-                                            });
-                                          },
-                                        );
-                                      },
-                              ),
-                            ],
-                          ),
-                          Row(
-                            spacing: 10,
-                            children: <Widget>[
-                              TestButton(
-                                flex: 6,
-                                onPressed: (_pointMode ||
-                                        _polygonMode ||
-                                        _polylineMode ||
-                                        _deleteMode)
-                                    ? null
-                                    : () {
-                                        _showInputDialog(
-                                          text:
-                                              'How Many Bikes/Scooters Can Fit?',
-                                          hintText: 'Enter number of spots.',
-                                          onNext: () {
-                                            setState(() {
-                                              _type = AccessType.bikeRack;
-                                              _polylineMode = true;
-                                              _directions =
-                                                  "Mark the spot of the bike/scooter rack. Then define the path to the project area.";
-                                            });
-                                          },
-                                        );
-                                      },
-                                buttonText: 'Bike or Scooter Rack',
-                              ),
-                              TestButton(
-                                flex: 6,
-                                buttonText: 'Taxi or Rideshare',
-                                onPressed: (_pointMode ||
-                                        _polygonMode ||
-                                        _polylineMode ||
-                                        _deleteMode)
-                                    ? null
-                                    : () {
-                                        setState(() {
-                                          _type = AccessType.taxiAndRideShare;
-                                          _polylineMode = true;
-                                          _directions =
-                                              'Mark a point where the taxi dropped off. Then make a line to denote the path to the project area.';
-                                        });
-                                      },
-                              ),
-                            ],
-                          ),
-                          SizedBox(height: 20),
-                          Expanded(
-                            child: Row(
-                              spacing: 10,
-                              children: <Widget>[
-                                Expanded(
-                                  child: Row(
-                                    spacing: 10,
-                                    children: <Widget>[
-                                      Flexible(
-                                        child: EditButton(
-                                          text: 'Confirm Shape',
-                                          foregroundColor: Colors.green,
-                                          backgroundColor: Colors.white,
-                                          icon: const Icon(Icons.check),
-                                          iconColor: Colors.green,
-                                          onPressed: ((_polylineMode &&
-                                                      (_currentPolyline !=
-                                                              null &&
-                                                          _currentPolyline!
-                                                                  .points
-                                                                  .length >
-                                                              2)) ||
-                                                  (_polygonMode &&
-                                                      _polygonPoints.length >=
-                                                          3))
-                                              ? _finalizeShape
-                                              : null,
-                                        ),
-                                      ),
-                                      Flexible(
-                                        child: EditButton(
-                                          text: 'Cancel',
-                                          foregroundColor: Colors.red,
-                                          backgroundColor: Colors.white,
-                                          icon: const Icon(Icons.cancel),
-                                          iconColor: Colors.red,
-                                          onPressed: (_polylineMode ||
-                                                  _polygonMode)
-                                              ? () {
-                                                  setState(() {
-                                                    _pointMode = false;
-                                                    _polygonMode = false;
-                                                    _polylineMode = false;
-                                                    _polylineMarkers = {};
-                                                    _currentPolyline = null;
-                                                    _currentPolylinePoints = [];
-                                                    _visiblePolylineMarkers =
-                                                        {};
-                                                    _polygonMarkers = {};
-                                                    _currentPolygon = {};
-                                                    _directions =
-                                                        'Choose a category. Or, click finish if done.';
-                                                  });
-                                                  _polygonPoints = [];
-                                                }
-                                              : null,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                                Flexible(
-                                  flex: 0,
-                                  child: Align(
-                                    alignment: Alignment.centerRight,
-                                    child: EditButton(
-                                      text: 'Finish',
-                                      foregroundColor: Colors.black,
-                                      backgroundColor: Colors.white,
-                                      icon: const Icon(Icons.chevron_right,
-                                          color: Colors.black),
-                                      onPressed: (_polygonMode ||
-                                              _polylineMode ||
-                                              _deleteMode)
-                                          ? null
-                                          : () {
-                                              showDialog(
-                                                  context: context,
-                                                  builder: (context) {
-                                                    return TestFinishDialog(
-                                                      onNext: () {
-                                                        widget.activeTest
-                                                            .submitData(
-                                                                _accessData);
-                                                        Navigator.pushReplacement(
-                                                            context,
-                                                            MaterialPageRoute(
-                                                              builder: (context) =>
-                                                                  HomeScreen(),
-                                                            ));
-                                                        Navigator.push(
-                                                            context,
-                                                            MaterialPageRoute(
-                                                              builder: (context) =>
-                                                                  ProjectDetailsPage(
-                                                                      projectData:
-                                                                          widget
-                                                                              .activeProject),
-                                                            ));
-                                                      },
-                                                    );
-                                                  });
-                                            },
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ],
                 ),
               ),
+            ),
+            if (_deleteMode)
+              TestErrorText(
+                padding:
+                    EdgeInsets.fromLTRB(20, 0, 20, _bottomSheetHeight + 20),
+                text: "You are in delete mode.",
+              ),
+          ],
+        ),
+        bottomSheet: SizedBox(
+          height: _bottomSheetHeight,
+          child: Stack(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 12.0, vertical: 10.0),
+                decoration: BoxDecoration(
+                  gradient: defaultGrad,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(24.0),
+                    topRight: Radius.circular(24.0),
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black,
+                      offset: Offset(0.0, 1.0), //(x,y)
+                      blurRadius: 6.0,
+                    ),
+                  ],
+                ),
+                child: Column(
+                  children: [
+                    SizedBox(height: 5),
+                    Center(
+                      child: Text(
+                        'Identifying Access',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: placeYellow,
+                        ),
+                      ),
+                    ),
+                    Align(
+                      alignment: Alignment.topCenter,
+                      child: Text(
+                        'Mark where people enter the project area from.',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontStyle: FontStyle.italic,
+                          color: Colors.grey[400],
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 15),
+                    Center(
+                      child: Text(
+                        'Access Type',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 5),
+                    Row(
+                      spacing: 10,
+                      children: <Widget>[
+                        TestButton(
+                          flex: 6,
+                          buttonText: 'Parking',
+                          onPressed: (_pointMode ||
+                                  _polygonMode ||
+                                  _polylineMode ||
+                                  _deleteMode)
+                              ? null
+                              : () {
+                                  setState(() {
+                                    _type = AccessType.parking;
+                                    _polygonMode = true;
+                                    _directions =
+                                        'First, define the parking area by creating a polygon.';
+                                  });
+                                },
+                        ),
+                        TestButton(
+                          flex: 6,
+                          buttonText: 'Public Transport',
+                          onPressed: (_pointMode ||
+                                  _polygonMode ||
+                                  _polylineMode ||
+                                  _deleteMode)
+                              ? null
+                              : () {
+                                  _showInputDialog(
+                                    text: 'Enter the Route Number',
+                                    hintText: 'Route Number',
+                                    onNext: () {
+                                      setState(() {
+                                        _type = AccessType.transportStation;
+                                        _polylineMode = true;
+                                        _directions =
+                                            "Mark the spot of the transport station. Then define the path to the project area.";
+                                      });
+                                    },
+                                  );
+                                },
+                        ),
+                      ],
+                    ),
+                    Row(
+                      spacing: 10,
+                      children: <Widget>[
+                        TestButton(
+                          flex: 6,
+                          onPressed: (_pointMode ||
+                                  _polygonMode ||
+                                  _polylineMode ||
+                                  _deleteMode)
+                              ? null
+                              : () {
+                                  _showInputDialog(
+                                    text: 'How Many Bikes/Scooters Can Fit?',
+                                    hintText: 'Enter number of spots.',
+                                    onNext: () {
+                                      setState(() {
+                                        _type = AccessType.bikeRack;
+                                        _polylineMode = true;
+                                        _directions =
+                                            "Mark the spot of the bike/scooter rack. Then define the path to the project area.";
+                                      });
+                                    },
+                                  );
+                                },
+                          buttonText: 'Bike or Scooter Rack',
+                        ),
+                        TestButton(
+                          flex: 6,
+                          buttonText: 'Taxi or Rideshare',
+                          onPressed: (_pointMode ||
+                                  _polygonMode ||
+                                  _polylineMode ||
+                                  _deleteMode)
+                              ? null
+                              : () {
+                                  setState(() {
+                                    _type = AccessType.taxiAndRideShare;
+                                    _polylineMode = true;
+                                    _directions =
+                                        'Mark a point where the taxi dropped off. Then make a line to denote the path to the project area.';
+                                  });
+                                },
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 20),
+                    Expanded(
+                      child: Row(
+                        spacing: 10,
+                        children: <Widget>[
+                          Expanded(
+                            child: Row(
+                              spacing: 10,
+                              children: <Widget>[
+                                Flexible(
+                                  child: EditButton(
+                                    text: 'Confirm Shape',
+                                    foregroundColor: Colors.green,
+                                    backgroundColor: Colors.white,
+                                    icon: const Icon(Icons.check),
+                                    iconColor: Colors.green,
+                                    onPressed: ((_polylineMode &&
+                                                (_currentPolyline != null &&
+                                                    _currentPolyline!
+                                                            .points.length >
+                                                        2)) ||
+                                            (_polygonMode &&
+                                                _polygonPoints.length >= 3))
+                                        ? _finalizeShape
+                                        : null,
+                                  ),
+                                ),
+                                Flexible(
+                                  child: EditButton(
+                                    text: 'Cancel',
+                                    foregroundColor: Colors.red,
+                                    backgroundColor: Colors.white,
+                                    icon: const Icon(Icons.cancel),
+                                    iconColor: Colors.red,
+                                    onPressed: (_polylineMode || _polygonMode)
+                                        ? () {
+                                            setState(() {
+                                              _pointMode = false;
+                                              _polygonMode = false;
+                                              _polylineMode = false;
+                                              _polylineMarkers = {};
+                                              _currentPolyline = null;
+                                              _currentPolylinePoints = [];
+                                              _visiblePolylineMarkers = {};
+                                              _polygonMarkers = {};
+                                              _currentPolygon = {};
+                                              _directions =
+                                                  'Choose a category. Or, click finish if done.';
+                                            });
+                                            _polygonPoints = [];
+                                          }
+                                        : null,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          Flexible(
+                            flex: 0,
+                            child: Align(
+                              alignment: Alignment.centerRight,
+                              child: EditButton(
+                                text: 'Finish',
+                                foregroundColor: Colors.black,
+                                backgroundColor: Colors.white,
+                                icon: const Icon(Icons.chevron_right,
+                                    color: Colors.black),
+                                onPressed: (_polygonMode ||
+                                        _polylineMode ||
+                                        _deleteMode)
+                                    ? null
+                                    : () {
+                                        showDialog(
+                                            context: context,
+                                            builder: (context) {
+                                              return TestFinishDialog(
+                                                onNext: () {
+                                                  widget.activeTest
+                                                      .submitData(_accessData);
+                                                  Navigator.pushReplacement(
+                                                      context,
+                                                      MaterialPageRoute(
+                                                        builder: (context) =>
+                                                            HomeScreen(),
+                                                      ));
+                                                  Navigator.push(
+                                                      context,
+                                                      MaterialPageRoute(
+                                                        builder: (context) =>
+                                                            ProjectDetailsPage(
+                                                                projectData: widget
+                                                                    .activeProject),
+                                                      ));
+                                                },
+                                              );
+                                            });
+                                      },
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/lighting_profile_test.dart
+++ b/lib/lighting_profile_test.dart
@@ -147,6 +147,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
           timer.cancel();
           showDialog(
             context: context,
+            barrierDismissible: false,
             builder: (context) {
               return TimerEndDialog(onSubmit: () {
                 Navigator.pop(context);

--- a/lib/lighting_profile_test.dart
+++ b/lib/lighting_profile_test.dart
@@ -26,11 +26,10 @@ class LightingProfileTestPage extends StatefulWidget {
 }
 
 class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
-  bool _isLoading = true;
   bool _isTypeSelected = false;
   bool _outsidePoint = false;
   bool _isTestRunning = false;
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
 
   LightType? _selectedType;
   late GoogleMapController mapController;
@@ -56,7 +55,6 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
     _projectArea = _polygons.first.toMPLatLngList();
     _zoom = getIdealZoom(_projectArea, _location.toMPLatLng());
     _remainingSeconds = widget.activeTest.testDuration;
-    _isLoading = false;
   }
 
   @override
@@ -190,235 +188,224 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
       child: Scaffold(
         resizeToAvoidBottomInset: false,
         extendBody: true,
-        body: _isLoading
-            ? const Center(child: CircularProgressIndicator())
-            : Stack(
-                children: <Widget>[
-                  SizedBox(
-                    height: MediaQuery.sizeOf(context).height,
-                    child: GoogleMap(
-                      padding: EdgeInsets.only(bottom: _bottomSheetHeight),
-                      onMapCreated: _onMapCreated,
-                      initialCameraPosition:
-                          CameraPosition(target: _location, zoom: _zoom),
-                      markers: _markers,
-                      polygons: _polygons,
-                      onTap: _isTypeSelected ? _togglePoint : null,
-                      mapType: _currentMapType,
-                    ),
+        body: Stack(
+          children: <Widget>[
+            SizedBox(
+              height: MediaQuery.sizeOf(context).height,
+              child: GoogleMap(
+                padding: EdgeInsets.only(bottom: _bottomSheetHeight),
+                onMapCreated: _onMapCreated,
+                initialCameraPosition:
+                    CameraPosition(target: _location, zoom: _zoom),
+                markers: _markers,
+                polygons: _polygons,
+                onTap: _isTypeSelected ? _togglePoint : null,
+                mapType: _currentMapType,
+              ),
+            ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Padding(
+                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      setState(() {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                            _setLightType(null);
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      });
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                ),
+                Expanded(
+                  child: _directionsVisible
+                      ? Padding(
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: topOverlayPadding),
+                          child: DirectionsText(
+                            onTap: () {
+                              setState(() {
+                                _directionsVisible = !_directionsVisible;
+                              });
+                            },
+                            text: !_isTypeSelected
+                                ? 'Select a type of light.'
+                                : 'Drop a pin where the light is.',
+                          ),
+                        )
+                      : SizedBox(),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
+                  child: Column(
+                    spacing: 10,
                     children: <Widget>[
-                      Padding(
-                        padding:
-                            EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                        child: TimerButtonAndDisplay(
-                          onPressed: () {
-                            setState(() {
-                              if (_isTestRunning) {
-                                setState(() {
-                                  _isTestRunning = false;
-                                  _timer?.cancel();
-                                  _setLightType(null);
-                                });
-                              } else {
-                                _startTest();
-                              }
-                            });
-                          },
-                          isTestRunning: _isTestRunning,
-                          remainingSeconds: _remainingSeconds,
-                        ),
+                      DirectionsButton(
+                        onTap: () {
+                          setState(() {
+                            _directionsVisible = !_directionsVisible;
+                          });
+                        },
                       ),
-                      Expanded(
-                        child: _directionsVisible
-                            ? Padding(
-                                padding: EdgeInsets.symmetric(
-                                    horizontal: 15.0,
-                                    vertical: topOverlayPadding),
-                                child: DirectionsText(
-                                  onTap: () {
-                                    setState(() {
-                                      _directionsVisible = !_directionsVisible;
-                                    });
-                                  },
-                                  text: !_isTypeSelected
-                                      ? 'Select a type of light.'
-                                      : 'Drop a pin where the light is.',
-                                ),
-                              )
-                            : SizedBox(),
-                      ),
-                      Padding(
-                        padding:
-                            EdgeInsets.only(top: topOverlayPadding, right: 15),
-                        child: Column(
-                          spacing: 10,
-                          children: <Widget>[
-                            DirectionsButton(
-                              onTap: () {
-                                setState(() {
-                                  _directionsVisible = !_directionsVisible;
-                                });
-                              },
-                            ),
-                            CircularIconMapButton(
-                              backgroundColor: Colors.green,
-                              borderColor: Color(0xFF2D6040),
-                              onPressed: _toggleMapType,
-                              icon: const Icon(Icons.map),
-                            ),
-                          ],
-                        ),
+                      CircularIconMapButton(
+                        backgroundColor: Colors.green,
+                        borderColor: Color(0xFF2D6040),
+                        onPressed: _toggleMapType,
+                        icon: const Icon(Icons.map),
                       ),
                     ],
                   ),
-                  if (_outsidePoint)
-                    TestErrorText(
-                      padding: EdgeInsets.fromLTRB(
-                          50, 0, 50, _bottomSheetHeight + 20),
-                    ),
-                ],
+                ),
+              ],
+            ),
+            if (_outsidePoint)
+              TestErrorText(
+                padding:
+                    EdgeInsets.fromLTRB(50, 0, 50, _bottomSheetHeight + 20),
               ),
-        bottomSheet: _isLoading
-            ? SizedBox()
-            : SizedBox(
-                height: _bottomSheetHeight,
-                child: Stack(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0, vertical: 10.0),
-                      decoration: BoxDecoration(
-                        gradient: defaultGrad,
-                        borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(24.0),
-                          topRight: Radius.circular(24.0),
+          ],
+        ),
+        bottomSheet: SizedBox(
+          height: _bottomSheetHeight,
+          child: Stack(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 12.0, vertical: 10.0),
+                decoration: BoxDecoration(
+                  gradient: defaultGrad,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(24.0),
+                    topRight: Radius.circular(24.0),
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black,
+                      offset: Offset(0.0, 1.0), //(x,y)
+                      blurRadius: 6.0,
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Center(
+                      child: Text(
+                        'Lighting Profile',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.yellow[600],
                         ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black,
-                            offset: Offset(0.0, 1.0), //(x,y)
-                            blurRadius: 6.0,
-                          ),
-                        ],
                       ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Center(
-                            child: Text(
-                              'Lighting Profile',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: Colors.yellow[600],
-                              ),
-                            ),
+                    ),
+                    SizedBox(height: 5),
+                    Row(
+                      spacing: 10,
+                      children: <Widget>[
+                        Expanded(
+                          flex: 6,
+                          child: FilledButton(
+                            style: testButtonStyle,
+                            onPressed: (!_isTypeSelected && _isTestRunning)
+                                ? () => _setLightType(LightType.rhythmic)
+                                : null,
+                            child: Text('Rhythmic'),
                           ),
-                          SizedBox(height: 5),
-                          Row(
-                            spacing: 10,
-                            children: <Widget>[
-                              Expanded(
-                                flex: 6,
-                                child: FilledButton(
-                                  style: testButtonStyle,
-                                  onPressed: (!_isTypeSelected &&
-                                          _isTestRunning)
-                                      ? () => _setLightType(LightType.rhythmic)
-                                      : null,
-                                  child: Text('Rhythmic'),
-                                ),
-                              ),
-                              Expanded(
-                                flex: 6,
-                                child: FilledButton(
-                                  style: testButtonStyle,
-                                  onPressed: (!_isTypeSelected &&
-                                          _isTestRunning)
-                                      ? () => _setLightType(LightType.building)
-                                      : null,
-                                  child: Text('Building'),
-                                ),
-                              ),
-                              Expanded(
-                                flex: 5,
-                                child: FilledButton(
-                                  style: testButtonStyle,
-                                  onPressed:
-                                      (!_isTypeSelected && _isTestRunning)
-                                          ? () => _setLightType(LightType.task)
-                                          : null,
-                                  child: Text('Task'),
-                                ),
-                              ),
-                            ],
+                        ),
+                        Expanded(
+                          flex: 6,
+                          child: FilledButton(
+                            style: testButtonStyle,
+                            onPressed: (!_isTypeSelected && _isTestRunning)
+                                ? () => _setLightType(LightType.building)
+                                : null,
+                            child: Text('Building'),
                           ),
-                          SizedBox(height: 5),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            spacing: 10,
-                            children: <Widget>[
-                              Spacer(flex: 1),
-                              Expanded(
-                                flex: 8,
-                                child: FilledButton(
-                                  style: testButtonStyle,
-                                  onPressed: (_isTypeSelected)
-                                      ? () => _setLightType(null)
-                                      : null,
-                                  child: Text('Select New Light Type'),
-                                ),
-                              ),
-                              Spacer(flex: 1),
-                            ],
+                        ),
+                        Expanded(
+                          flex: 5,
+                          child: FilledButton(
+                            style: testButtonStyle,
+                            onPressed: (!_isTypeSelected && _isTestRunning)
+                                ? () => _setLightType(LightType.task)
+                                : null,
+                            child: Text('Task'),
                           ),
-                          SizedBox(height: 10),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            spacing: 10,
-                            children: <Widget>[
-                              Flexible(
-                                child: FilledButton.icon(
-                                  style: testButtonStyle,
-                                  onPressed: () => Navigator.pop(context),
-                                  label: Text('Back'),
-                                  icon: Icon(Icons.chevron_left),
-                                  iconAlignment: IconAlignment.start,
-                                ),
-                              ),
-                              Flexible(
-                                child: FilledButton.icon(
-                                  style: testButtonStyle,
-                                  onPressed: (!_isTypeSelected &&
-                                          !_isTestRunning)
-                                      ? () {
-                                          showDialog(
-                                            context: context,
-                                            builder: (context) =>
-                                                TestFinishDialog(onNext: () {
-                                              Navigator.pop(context);
-                                              _endTest();
-                                            }),
-                                          );
-                                        }
-                                      : null,
-                                  label: Text('Finish'),
-                                  icon: Icon(Icons.chevron_right),
-                                  iconAlignment: IconAlignment.end,
-                                ),
-                              ),
-                            ],
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 5),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      spacing: 10,
+                      children: <Widget>[
+                        Spacer(flex: 1),
+                        Expanded(
+                          flex: 8,
+                          child: FilledButton(
+                            style: testButtonStyle,
+                            onPressed: (_isTypeSelected)
+                                ? () => _setLightType(null)
+                                : null,
+                            child: Text('Select New Light Type'),
                           ),
-                        ],
-                      ),
+                        ),
+                        Spacer(flex: 1),
+                      ],
+                    ),
+                    SizedBox(height: 10),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      spacing: 10,
+                      children: <Widget>[
+                        Flexible(
+                          child: FilledButton.icon(
+                            style: testButtonStyle,
+                            onPressed: () => Navigator.pop(context),
+                            label: Text('Back'),
+                            icon: Icon(Icons.chevron_left),
+                            iconAlignment: IconAlignment.start,
+                          ),
+                        ),
+                        Flexible(
+                          child: FilledButton.icon(
+                            style: testButtonStyle,
+                            onPressed: (!_isTypeSelected && !_isTestRunning)
+                                ? () {
+                                    showDialog(
+                                      context: context,
+                                      builder: (context) =>
+                                          TestFinishDialog(onNext: () {
+                                        Navigator.pop(context);
+                                        _endTest();
+                                      }),
+                                    );
+                                  }
+                                : null,
+                            label: Text('Finish'),
+                            icon: Icon(Icons.chevron_right),
+                            iconAlignment: IconAlignment.end,
+                          ),
+                        ),
+                      ],
                     ),
                   ],
                 ),
               ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/lighting_profile_test.dart
+++ b/lib/lighting_profile_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -45,7 +46,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
   Timer? _timer;
   Timer? _outsidePointTimer;
   int _remainingSeconds = -1;
-  static const double _bottomSheetHeight = 220;
+  static final double _bottomSheetHeight = Platform.isIOS ? 260 : 220;
 
   @override
   void initState() {
@@ -184,6 +185,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         resizeToAvoidBottomInset: false,
@@ -210,7 +212,8 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: <Widget>[
                       Padding(
-                        padding: const EdgeInsets.only(top: 15.0, left: 15.0),
+                        padding:
+                            EdgeInsets.only(top: topOverlayPadding, left: 15.0),
                         child: TimerButtonAndDisplay(
                           onPressed: () {
                             setState(() {
@@ -232,8 +235,9 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
                       Expanded(
                         child: _directionsVisible
                             ? Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 15.0, vertical: 15.0),
+                                padding: EdgeInsets.symmetric(
+                                    horizontal: 15.0,
+                                    vertical: topOverlayPadding),
                                 child: DirectionsText(
                                   onTap: () {
                                     setState(() {
@@ -248,7 +252,8 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
                             : SizedBox(),
                       ),
                       Padding(
-                        padding: const EdgeInsets.only(top: 15, right: 15),
+                        padding:
+                            EdgeInsets.only(top: topOverlayPadding, right: 15),
                         child: Column(
                           spacing: 10,
                           children: <Widget>[

--- a/lib/lighting_profile_test.dart
+++ b/lib/lighting_profile_test.dart
@@ -43,6 +43,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
   final LightingProfileData _newData = LightingProfileData();
 
   Timer? _timer;
+  Timer? _outsidePointTimer;
   int _remainingSeconds = -1;
   static const double _bottomSheetHeight = 220;
 
@@ -60,6 +61,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
   @override
   void dispose() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     super.dispose();
   }
 
@@ -97,6 +99,12 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
         setState(() {
           _outsidePoint = true;
         });
+        _outsidePointTimer?.cancel();
+        _outsidePointTimer = Timer(Duration(seconds: 3), () {
+          setState(() {
+            _outsidePoint = false;
+          });
+        });
       }
 
       _newData.lights.add(Light(
@@ -121,14 +129,6 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
           ),
         );
       });
-
-      if (_outsidePoint) {
-        // TODO: fix delay. delay will overlap with consecutive taps. this means taps do not necessarily refresh the timer and will end prematurely
-        await Future.delayed(const Duration(seconds: 2));
-        setState(() {
-          _outsidePoint = false;
-        });
-      }
     } catch (e, stacktrace) {
       print('Error in lighting_profile_test.dart, _togglePoint(): $e');
       print('Stacktrace: $stacktrace');
@@ -168,6 +168,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
   /// Cancels timer, submits data, and pops test page.
   void _endTest() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     widget.activeTest.submitData(_newData);
     Navigator.pop(context);
   }

--- a/lib/lighting_profile_test.dart
+++ b/lib/lighting_profile_test.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:maps_toolkit/maps_toolkit.dart' as mp;
 import 'package:p2bp_2025spring_mobile/firestore_functions.dart';
@@ -45,7 +45,7 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
   Timer? _timer;
   Timer? _outsidePointTimer;
   int _remainingSeconds = -1;
-  static final double _bottomSheetHeight = Platform.isIOS ? 260 : 220;
+  static const double _bottomSheetHeight = 220;
 
   @override
   void initState() {
@@ -183,8 +183,14 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
 
   @override
   Widget build(BuildContext context) {
-    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
-    return AdaptiveSafeArea(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: (_currentMapType == MapType.normal)
+          ? SystemUiOverlayStyle.dark.copyWith(
+              statusBarColor: Colors.transparent,
+            )
+          : SystemUiOverlayStyle.light.copyWith(
+              statusBarColor: Colors.transparent,
+            ),
       child: Scaffold(
         resizeToAvoidBottomInset: false,
         extendBody: true,
@@ -203,70 +209,67 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
                 mapType: _currentMapType,
               ),
             ),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      setState(() {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                            _setLightType(null);
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      });
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
-                  ),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    TimerButtonAndDisplay(
+                      onPressed: () {
+                        setState(() {
+                          if (_isTestRunning) {
+                            setState(() {
+                              _isTestRunning = false;
+                              _timer?.cancel();
+                              _setLightType(null);
+                            });
+                          } else {
+                            _startTest();
+                          }
+                        });
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
+                    SizedBox(width: 15),
+                    Expanded(
+                      child: _directionsVisible
+                          ? DirectionsText(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
+                              text: !_isTypeSelected
+                                  ? 'Select a type of light.'
+                                  : 'Drop a pin where the light is.',
+                            )
+                          : SizedBox(),
+                    ),
+                    SizedBox(width: 15),
+                    Column(
+                      spacing: 10,
+                      children: <Widget>[
+                        DirectionsButton(
+                          onTap: () {
+                            setState(() {
+                              _directionsVisible = !_directionsVisible;
+                            });
+                          },
+                        ),
+                        CircularIconMapButton(
+                          backgroundColor: Colors.green,
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: const Icon(Icons.map),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
-                Expanded(
-                  child: _directionsVisible
-                      ? Padding(
-                          padding: EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: topOverlayPadding),
-                          child: DirectionsText(
-                            onTap: () {
-                              setState(() {
-                                _directionsVisible = !_directionsVisible;
-                              });
-                            },
-                            text: !_isTypeSelected
-                                ? 'Select a type of light.'
-                                : 'Drop a pin where the light is.',
-                          ),
-                        )
-                      : SizedBox(),
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
-                  child: Column(
-                    spacing: 10,
-                    children: <Widget>[
-                      DirectionsButton(
-                        onTap: () {
-                          setState(() {
-                            _directionsVisible = !_directionsVisible;
-                          });
-                        },
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor: Colors.green,
-                        borderColor: Color(0xFF2D6040),
-                        onPressed: _toggleMapType,
-                        icon: const Icon(Icons.map),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+              ),
             ),
             if (_outsidePoint)
               TestErrorText(
@@ -277,133 +280,129 @@ class _LightingProfileTestPageState extends State<LightingProfileTestPage> {
         ),
         bottomSheet: SizedBox(
           height: _bottomSheetHeight,
-          child: Stack(
-            children: [
-              Container(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 12.0, vertical: 10.0),
-                decoration: BoxDecoration(
-                  gradient: defaultGrad,
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(24.0),
-                    topRight: Radius.circular(24.0),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black,
-                      offset: Offset(0.0, 1.0), //(x,y)
-                      blurRadius: 6.0,
-                    ),
-                  ],
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+            decoration: BoxDecoration(
+              gradient: defaultGrad,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(24.0),
+                topRight: Radius.circular(24.0),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black,
+                  offset: Offset(0.0, 1.0), //(x,y)
+                  blurRadius: 6.0,
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Center(
+                  child: Text(
+                    'Lighting Profile',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.yellow[600],
+                    ),
+                  ),
+                ),
+                SizedBox(height: 5),
+                Row(
+                  spacing: 10,
                   children: <Widget>[
-                    Center(
-                      child: Text(
-                        'Lighting Profile',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.yellow[600],
-                        ),
+                    Expanded(
+                      flex: 6,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed: (!_isTypeSelected && _isTestRunning)
+                            ? () => _setLightType(LightType.rhythmic)
+                            : null,
+                        child: Text('Rhythmic'),
                       ),
                     ),
-                    SizedBox(height: 5),
-                    Row(
-                      spacing: 10,
-                      children: <Widget>[
-                        Expanded(
-                          flex: 6,
-                          child: FilledButton(
-                            style: testButtonStyle,
-                            onPressed: (!_isTypeSelected && _isTestRunning)
-                                ? () => _setLightType(LightType.rhythmic)
-                                : null,
-                            child: Text('Rhythmic'),
-                          ),
-                        ),
-                        Expanded(
-                          flex: 6,
-                          child: FilledButton(
-                            style: testButtonStyle,
-                            onPressed: (!_isTypeSelected && _isTestRunning)
-                                ? () => _setLightType(LightType.building)
-                                : null,
-                            child: Text('Building'),
-                          ),
-                        ),
-                        Expanded(
-                          flex: 5,
-                          child: FilledButton(
-                            style: testButtonStyle,
-                            onPressed: (!_isTypeSelected && _isTestRunning)
-                                ? () => _setLightType(LightType.task)
-                                : null,
-                            child: Text('Task'),
-                          ),
-                        ),
-                      ],
+                    Expanded(
+                      flex: 6,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed: (!_isTypeSelected && _isTestRunning)
+                            ? () => _setLightType(LightType.building)
+                            : null,
+                        child: Text('Building'),
+                      ),
                     ),
-                    SizedBox(height: 5),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      spacing: 10,
-                      children: <Widget>[
-                        Spacer(flex: 1),
-                        Expanded(
-                          flex: 8,
-                          child: FilledButton(
-                            style: testButtonStyle,
-                            onPressed: (_isTypeSelected)
-                                ? () => _setLightType(null)
-                                : null,
-                            child: Text('Select New Light Type'),
-                          ),
-                        ),
-                        Spacer(flex: 1),
-                      ],
-                    ),
-                    SizedBox(height: 10),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      spacing: 10,
-                      children: <Widget>[
-                        Flexible(
-                          child: FilledButton.icon(
-                            style: testButtonStyle,
-                            onPressed: () => Navigator.pop(context),
-                            label: Text('Back'),
-                            icon: Icon(Icons.chevron_left),
-                            iconAlignment: IconAlignment.start,
-                          ),
-                        ),
-                        Flexible(
-                          child: FilledButton.icon(
-                            style: testButtonStyle,
-                            onPressed: (!_isTypeSelected && !_isTestRunning)
-                                ? () {
-                                    showDialog(
-                                      context: context,
-                                      builder: (context) =>
-                                          TestFinishDialog(onNext: () {
-                                        Navigator.pop(context);
-                                        _endTest();
-                                      }),
-                                    );
-                                  }
-                                : null,
-                            label: Text('Finish'),
-                            icon: Icon(Icons.chevron_right),
-                            iconAlignment: IconAlignment.end,
-                          ),
-                        ),
-                      ],
+                    Expanded(
+                      flex: 5,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed: (!_isTypeSelected && _isTestRunning)
+                            ? () => _setLightType(LightType.task)
+                            : null,
+                        child: Text('Task'),
+                      ),
                     ),
                   ],
                 ),
-              ),
-            ],
+                SizedBox(height: 5),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  spacing: 10,
+                  children: <Widget>[
+                    Spacer(flex: 1),
+                    Expanded(
+                      flex: 8,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed: (_isTypeSelected)
+                            ? () => _setLightType(null)
+                            : null,
+                        child: Text('Select New Light Type'),
+                      ),
+                    ),
+                    Spacer(flex: 1),
+                  ],
+                ),
+                SizedBox(height: 10),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  spacing: 10,
+                  children: <Widget>[
+                    Flexible(
+                      child: FilledButton.icon(
+                        style: testButtonStyle,
+                        onPressed: () => Navigator.pop(context),
+                        label: Text('Back'),
+                        icon: Icon(Icons.chevron_left),
+                        iconAlignment: IconAlignment.start,
+                      ),
+                    ),
+                    Flexible(
+                      child: FilledButton.icon(
+                        style: testButtonStyle,
+                        onPressed: (!_isTypeSelected && !_isTestRunning)
+                            ? () {
+                                showDialog(
+                                  context: context,
+                                  builder: (context) =>
+                                      TestFinishDialog(onNext: () {
+                                    Navigator.pop(context);
+                                    _endTest();
+                                  }),
+                                );
+                              }
+                            : null,
+                        label: Text('Finish'),
+                        icon: Icon(Icons.chevron_right),
+                        iconAlignment: IconAlignment.end,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -144,6 +144,13 @@ class _LoginFormState extends State<LoginForm> {
   String _fullName = '';
 
   @override
+  void initState() {
+    super.initState();
+    _emailController.text = 'ryanjgiunta@gmail.com';
+    _passwordController.text = 'Password!!11';
+  }
+
+  @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -144,13 +144,6 @@ class _LoginFormState extends State<LoginForm> {
   String _fullName = '';
 
   @override
-  void initState() {
-    super.initState();
-    _emailController.text = 'ryanjgiunta@gmail.com';
-    _passwordController.text = 'Password!!11';
-  }
-
-  @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
@@ -39,7 +40,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
   List<mp.LatLng> _projectArea = [];
   String _directions = "Choose a category.";
   bool _directionsVisible = false;
-  static const double _bottomSheetHeight = 300;
+  static const double _bottomSheetHeight = 320;
   late DocumentReference teamRef;
   late GoogleMapController mapController;
   LatLng _location = defaultLocation; // Default location
@@ -629,6 +630,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         resizeToAvoidBottomInset: false,
@@ -658,28 +660,31 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      if (_isTestRunning) {
-                        setState(() {
-                          _isTestRunning = false;
-                          _timer?.cancel();
-                          _clearTypes();
-                        });
-                      } else {
-                        _startTest();
-                      }
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
+                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
+                  child: SizedBox(
+                    width: 75,
+                    child: TimerButtonAndDisplay(
+                      onPressed: () {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                            _clearTypes();
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
                   ),
                 ),
                 Expanded(
                   child: _directionsVisible
                       ? Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: 15.0),
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: topOverlayPadding),
                           child: DirectionsText(
                               onTap: () {
                                 setState(() {
@@ -691,7 +696,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                       : SizedBox(),
                 ),
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, right: 15.0),
+                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15.0),
                   child: Column(
                     spacing: 10,
                     children: [

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -791,7 +791,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
       if (_natureType == NatureType.vegetation) {
         tempPolygon = finalizePolygon(
           _polygonPoints,
-          polygonColor: Vegetation.vegetationTypeToColor[_vegetationType],
+          strokeColor: Vegetation.vegetationTypeToColor[_vegetationType],
         );
         // Create polygon.
         _polygons.addAll(tempPolygon);
@@ -801,7 +801,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
             otherType: _otherType));
       } else if (_natureType == NatureType.waterBody) {
         tempPolygon = finalizePolygon(_polygonPoints,
-            polygonColor: WaterBody.waterBodyTypeToColor[_waterBodyType]);
+            strokeColor: WaterBody.waterBodyTypeToColor[_waterBodyType]);
         // Create polygon.
         _polygons.addAll(tempPolygon);
         _waterBodyData.add(WaterBody(

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -39,7 +39,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
   late final Polygon _projectPolygon;
   List<mp.LatLng> _projectArea = [];
   String _directions = "Choose a category.";
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
   static const double _bottomSheetHeight = 320;
   late DocumentReference teamRef;
   late GoogleMapController mapController;
@@ -661,23 +661,20 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
               children: <Widget>[
                 Padding(
                   padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: SizedBox(
-                    width: 75,
-                    child: TimerButtonAndDisplay(
-                      onPressed: () {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                            _clearTypes();
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      },
-                      isTestRunning: _isTestRunning,
-                      remainingSeconds: _remainingSeconds,
-                    ),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      if (_isTestRunning) {
+                        setState(() {
+                          _isTestRunning = false;
+                          _timer?.cancel();
+                          _clearTypes();
+                        });
+                      } else {
+                        _startTest();
+                      }
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
                 ),
                 Expanded(

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -164,219 +164,13 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
 
   void _setWeatherData() async {
     WeatherData? weatherData;
-    double? temperature;
-    bool erroredTemp = false;
-    bool erroredSelect = false;
-    Map<Weather, bool> selectedMap = {
-      Weather.stormy: false,
-      Weather.sunny: false,
-      Weather.rainy: false,
-      Weather.windy: false,
-      Weather.cloudy: false,
-    };
+
     try {
       weatherData = await showDialog(
           barrierDismissible: false,
           context: context,
           builder: (context) {
-            return StatefulBuilder(builder: (context, StateSetter setState) {
-              return AlertDialog(
-                scrollable: true,
-                title: Column(
-                  children: [
-                    Text(
-                      'Weather',
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ],
-                ),
-                content: Column(
-                  spacing: 5,
-                  children: [
-                    Text(
-                      'Temperature',
-                      style:
-                          TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-                    ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      spacing: 10,
-                      children: [
-                        Flexible(
-                          child: DialogTextBox(
-                            textAlign: TextAlign.center,
-                            inputFormatter: [
-                              FilteringTextInputFormatter.allow(
-                                  RegExp('[1234567890.-]'))
-                            ],
-                            keyboardType: TextInputType.numberWithOptions(
-                                signed: true, decimal: true),
-                            maxLength: 6,
-                            labelText: 'Temp.',
-                            onChanged: (inputText) {
-                              setState(() {
-                                erroredTemp = false;
-                              });
-                              temperature = double.tryParse(inputText);
-                            },
-                          ),
-                        ),
-                        Flexible(
-                            child: Text(
-                          '°F',
-                          style: TextStyle(fontSize: 14),
-                        ))
-                      ],
-                    ),
-                    erroredTemp
-                        ? Text(
-                            "Please input a value!",
-                            style: TextStyle(color: Colors.red[900]),
-                          )
-                        : SizedBox(),
-                    SizedBox(height: 30),
-                    Center(
-                      child: Text(
-                        "Type",
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold, fontSize: 16),
-                      ),
-                    ),
-                    Row(
-                      spacing: 5,
-                      children: <Widget>[
-                        TestButton(
-                          buttonText: "Sunny",
-                          backgroundColor: selectedMap[Weather.sunny] == true
-                              ? Colors.blue
-                              : null,
-                          onPressed: () {
-                            setState(() {
-                              erroredSelect = false;
-                              selectedMap[Weather.sunny] =
-                                  !selectedMap[Weather.sunny]!;
-                            });
-                          },
-                        ),
-                        TestButton(
-                          buttonText: "Rainy",
-                          backgroundColor: selectedMap[Weather.rainy] == true
-                              ? Colors.blue
-                              : null,
-                          onPressed: () {
-                            setState(() {
-                              erroredSelect = false;
-                              selectedMap[Weather.rainy] =
-                                  !selectedMap[Weather.rainy]!;
-                            });
-                          },
-                        )
-                      ],
-                    ),
-                    Row(
-                      spacing: 5,
-                      children: <Widget>[
-                        TestButton(
-                          buttonText: "Windy",
-                          backgroundColor: selectedMap[Weather.windy] == true
-                              ? Colors.blue
-                              : null,
-                          onPressed: () {
-                            setState(() {
-                              erroredSelect = false;
-                              selectedMap[Weather.windy] =
-                                  !selectedMap[Weather.windy]!;
-                            });
-                          },
-                        ),
-                        TestButton(
-                          buttonText: "Stormy",
-                          backgroundColor: selectedMap[Weather.stormy] == true
-                              ? Colors.blue
-                              : null,
-                          onPressed: () {
-                            setState(() {
-                              erroredSelect = false;
-                              selectedMap[Weather.stormy] =
-                                  !selectedMap[Weather.stormy]!;
-                            });
-                          },
-                        )
-                      ],
-                    ),
-                    Row(
-                      spacing: 5,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Spacer(),
-                        TestButton(
-                          flex: 2,
-                          buttonText: "Cloudy",
-                          backgroundColor: selectedMap[Weather.cloudy] == true
-                              ? Colors.blue
-                              : null,
-                          onPressed: () {
-                            setState(() {
-                              erroredSelect = false;
-                              selectedMap[Weather.cloudy] =
-                                  !selectedMap[Weather.cloudy]!;
-                            });
-                          },
-                        ),
-                        Spacer(),
-                      ],
-                    ),
-                    erroredSelect
-                        ? Text(
-                            "Please select a type!",
-                            style: TextStyle(color: Colors.red[900]),
-                          )
-                        : SizedBox(),
-                  ],
-                ),
-                actions: <Widget>[
-                  TextButton(
-                    onPressed: () {
-                      Navigator.pop(context, null);
-                    },
-                    child: const Text('Cancel'),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      List<Weather> selectedWeather = [];
-                      for (Weather weatherType in selectedMap.keys) {
-                        if (selectedMap[weatherType] != null &&
-                            selectedMap[weatherType] == true) {
-                          selectedWeather.add(weatherType);
-                        }
-                      }
-                      if (temperature == null) {
-                        setState(() {
-                          erroredTemp = true;
-                        });
-                      }
-                      print(erroredSelect);
-                      if (selectedWeather.isEmpty) {
-                        print("\n");
-                        setState(() {
-                          erroredSelect = true;
-                        });
-                      }
-                      if (erroredSelect || erroredTemp) {
-                        return;
-                      }
-                      weatherData = WeatherData(
-                          weatherTypes: selectedWeather, temp: temperature!);
-                      Navigator.pop(context, weatherData);
-                      print('${weatherData!.weatherTypes} temp: $temperature');
-                    },
-                    child: const Text('Next'),
-                  ),
-                ],
-              );
-            });
+            return WeatherDialog();
           });
       if (weatherData == null && mounted) {
         Navigator.pop(context);
@@ -1195,6 +989,217 @@ class DisplayModalButton extends StatelessWidget {
         icon: icon,
         iconAlignment: IconAlignment.end,
       ),
+    );
+  }
+}
+
+class WeatherDialog extends StatefulWidget {
+  const WeatherDialog({super.key});
+
+  @override
+  State<WeatherDialog> createState() => _WeatherDialogState();
+}
+
+class _WeatherDialogState extends State<WeatherDialog> {
+  WeatherData? weatherData;
+  double? temperature;
+  bool erroredTemp = false;
+  bool erroredSelect = false;
+  Map<WeatherType, bool> selectedMap = {
+    for (final weather in WeatherType.values) weather: false
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      scrollable: true,
+      title: Column(
+        children: [
+          Text(
+            'Weather',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        spacing: 5,
+        children: [
+          Text(
+            'Temperature',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            spacing: 10,
+            children: [
+              Flexible(
+                child: DialogTextBox(
+                  textAlign: TextAlign.center,
+                  inputFormatter: [
+                    FilteringTextInputFormatter.allow(RegExp('[1234567890.-]'))
+                  ],
+                  keyboardType: TextInputType.numberWithOptions(
+                      signed: true, decimal: true),
+                  maxLength: 6,
+                  labelText: 'Temp.',
+                  onChanged: (inputText) {
+                    setState(() {
+                      erroredTemp = false;
+                    });
+                    temperature = double.tryParse(inputText);
+                  },
+                ),
+              ),
+              Flexible(
+                  child: Text(
+                '°F',
+                style: TextStyle(fontSize: 14),
+              ))
+            ],
+          ),
+          erroredTemp
+              ? Text(
+                  "Please input a value!",
+                  style: TextStyle(color: Colors.red[900]),
+                )
+              : SizedBox(),
+          SizedBox(height: 30),
+          Center(
+            child: Text(
+              "Type",
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+          ),
+          Row(
+            spacing: 5,
+            children: <Widget>[
+              TestButton(
+                buttonText: "Sunny",
+                backgroundColor:
+                    selectedMap[WeatherType.sunny] == true ? Colors.blue : null,
+                onPressed: () {
+                  setState(() {
+                    erroredSelect = false;
+                    selectedMap[WeatherType.sunny] =
+                        !selectedMap[WeatherType.sunny]!;
+                  });
+                },
+              ),
+              TestButton(
+                buttonText: "Rainy",
+                backgroundColor:
+                    selectedMap[WeatherType.rainy] == true ? Colors.blue : null,
+                onPressed: () {
+                  setState(() {
+                    erroredSelect = false;
+                    selectedMap[WeatherType.rainy] =
+                        !selectedMap[WeatherType.rainy]!;
+                  });
+                },
+              )
+            ],
+          ),
+          Row(
+            spacing: 5,
+            children: <Widget>[
+              TestButton(
+                buttonText: "Windy",
+                backgroundColor:
+                    selectedMap[WeatherType.windy] == true ? Colors.blue : null,
+                onPressed: () {
+                  setState(() {
+                    erroredSelect = false;
+                    selectedMap[WeatherType.windy] =
+                        !selectedMap[WeatherType.windy]!;
+                  });
+                },
+              ),
+              TestButton(
+                buttonText: "Stormy",
+                backgroundColor: selectedMap[WeatherType.stormy] == true
+                    ? Colors.blue
+                    : null,
+                onPressed: () {
+                  setState(() {
+                    erroredSelect = false;
+                    selectedMap[WeatherType.stormy] =
+                        !selectedMap[WeatherType.stormy]!;
+                  });
+                },
+              )
+            ],
+          ),
+          Row(
+            spacing: 5,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Spacer(),
+              TestButton(
+                flex: 2,
+                buttonText: "Cloudy",
+                backgroundColor: selectedMap[WeatherType.cloudy] == true
+                    ? Colors.blue
+                    : null,
+                onPressed: () {
+                  setState(() {
+                    erroredSelect = false;
+                    selectedMap[WeatherType.cloudy] =
+                        !selectedMap[WeatherType.cloudy]!;
+                  });
+                },
+              ),
+              Spacer(),
+            ],
+          ),
+          erroredSelect
+              ? Text(
+                  "Please select a type!",
+                  style: TextStyle(color: Colors.red[900]),
+                )
+              : SizedBox(),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            Navigator.pop(context, null);
+          },
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () {
+            List<WeatherType> selectedWeather = [];
+            for (WeatherType weatherType in selectedMap.keys) {
+              if (selectedMap[weatherType] != null &&
+                  selectedMap[weatherType] == true) {
+                selectedWeather.add(weatherType);
+              }
+            }
+            if (temperature == null) {
+              setState(() {
+                erroredTemp = true;
+              });
+            }
+            print(erroredSelect);
+            if (selectedWeather.isEmpty) {
+              print("\n");
+              setState(() {
+                erroredSelect = true;
+              });
+            }
+            if (erroredSelect || erroredTemp) {
+              return;
+            }
+            weatherData =
+                WeatherData(weatherTypes: selectedWeather, temp: temperature!);
+            Navigator.pop(context, weatherData);
+            print('${weatherData!.weatherTypes} temp: $temperature');
+          },
+          child: const Text('Next'),
+        ),
+      ],
     );
   }
 }

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -103,6 +103,7 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
           timer.cancel();
           showDialog(
             context: context,
+            barrierDismissible: false,
             builder: (context) {
               return TimerEndDialog(onSubmit: () {
                 Navigator.pop(context);

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -287,6 +287,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
 
   void _endTest() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     widget.activeTest.submitData(_newData);
     Navigator.pop(context);
   }

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -32,7 +32,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
   bool _isTracingMode = false;
   bool _outsidePoint = false;
   bool _isPointsMenuVisible = false;
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
 
   double _zoom = 18;
   late GoogleMapController mapController;
@@ -341,25 +341,22 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
               children: <Widget>[
                 Padding(
                   padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: SizedBox(
-                    width: 75,
-                    child: TimerButtonAndDisplay(
-                      onPressed: () {
-                        setState(() {
-                          if (_isTestRunning) {
-                            setState(() {
-                              _isTestRunning = false;
-                              _timer?.cancel();
-                              _clearTracing();
-                            });
-                          } else {
-                            _startTest();
-                          }
-                        });
-                      },
-                      isTestRunning: _isTestRunning,
-                      remainingSeconds: _remainingSeconds,
-                    ),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      setState(() {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                            _clearTracing();
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      });
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
                 ),
                 Expanded(

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -12,12 +12,6 @@ import 'package:p2bp_2025spring_mobile/db_schema_classes.dart';
 import 'package:p2bp_2025spring_mobile/people_in_motion_instructions.dart';
 import 'package:maps_toolkit/maps_toolkit.dart' as mp;
 
-final AssetMapBitmap tempMarkerIcon = AssetMapBitmap(
-  'assets/test_specific/people_in_motion/polyline_marker4.png',
-  width: 48,
-  height: 48,
-);
-
 class PeopleInMotionTestPage extends StatefulWidget {
   final Project activeProject;
   final PeopleInMotionTest activeTest;
@@ -71,6 +65,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
   // Define an initial time
   int _remainingSeconds = -1;
   Timer? _timer;
+  Timer? _outsidePointTimer;
 
   @override
   void initState() {
@@ -97,6 +92,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
   @override
   void dispose() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     super.dispose();
   }
 
@@ -106,7 +102,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          insetPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          insetPadding: const EdgeInsets.all(10),
           actionsPadding: EdgeInsets.zero,
           title: Text(
             'How It Works:',
@@ -182,7 +178,8 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
       setState(() {
         _outsidePoint = true;
       });
-      Timer(Duration(seconds: 3), () {
+      _outsidePointTimer?.cancel();
+      _outsidePointTimer = Timer(Duration(seconds: 3), () {
         setState(() {
           _outsidePoint = false;
         });

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -33,20 +33,17 @@ class PeopleInMotionTestPage extends StatefulWidget {
 }
 
 class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
-  bool _isLoading = true;
   bool _isTestRunning = false;
   bool _isTracingMode = false;
-  bool _showErrorMessage = false;
+  bool _outsidePoint = false;
   bool _isPointsMenuVisible = false;
+  bool _directionsVisible = false;
 
   double _zoom = 18;
   late GoogleMapController mapController;
   LatLng _location = defaultLocation;
   List<mp.LatLng> _projectArea = [];
   final Set<Polygon> _polygons = {}; // Only gets project polygon.
-
-  Timer? _timer;
-
   MapType _currentMapType = MapType.satellite;
 
   /// Markers placed while in TracingMode.
@@ -69,11 +66,11 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
   final Set<Marker> _confirmedPolylineEndMarkers = {};
 
   final Set<Marker> _standingPointMarkers = {};
-
   final PeopleInMotionData _newData = PeopleInMotionData();
 
   // Define an initial time
-  int _remainingSeconds = 300;
+  int _remainingSeconds = -1;
+  Timer? _timer;
 
   @override
   void initState() {
@@ -82,7 +79,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
     _location = getPolygonCentroid(_polygons.first);
     _projectArea = _polygons.first.toMPLatLngList();
     _zoom = getIdealZoom(_projectArea, _location.toMPLatLng());
-    _isLoading = false;
+    _remainingSeconds = widget.activeTest.testDuration;
     for (final point in widget.activeTest.standingPoints) {
       _standingPointMarkers.add(Marker(
         markerId: MarkerId(point.toString()),
@@ -103,34 +100,13 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
     super.dispose();
   }
 
-  // Returns Marker icon for the given [ActivityTypeInMotion].
-  BitmapDescriptor _getMarkerIcon(ActivityTypeInMotion? key) {
-    switch (key) {
-      case ActivityTypeInMotion.walking:
-        return walkingConnector;
-      case ActivityTypeInMotion.running:
-        return runningConnector;
-      case ActivityTypeInMotion.swimming:
-        return swimmingConnector;
-      case ActivityTypeInMotion.activityOnWheels:
-        return wheelsConnector;
-      case ActivityTypeInMotion.handicapAssistedWheels:
-        return handicapConnector;
-      default:
-        return BitmapDescriptor.defaultMarker;
-    }
-  }
-
   void _showInstructionOverlay() {
     showDialog(
       context: context,
       barrierDismissible: false,
       builder: (context) {
-        final screenSize = MediaQuery.of(context).size;
         return AlertDialog(
-          insetPadding: EdgeInsets.symmetric(
-              horizontal: MediaQuery.of(context).size.width * 0.05,
-              vertical: MediaQuery.of(context).size.height * 0.005),
+          insetPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 10),
           actionsPadding: EdgeInsets.zero,
           title: Text(
             'How It Works:',
@@ -139,7 +115,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
           ),
           content: SingleChildScrollView(
             child: SizedBox(
-              width: screenSize.width * 0.95,
+              width: double.maxFinite,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -204,40 +180,37 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
     // If point is outside the project boundary, display error message
     if (!isPointInsidePolygon(point, _polygons.first)) {
       setState(() {
-        _showErrorMessage = true;
+        _outsidePoint = true;
       });
       Timer(Duration(seconds: 3), () {
         setState(() {
-          _showErrorMessage = false;
+          _outsidePoint = false;
         });
       });
     }
-    if (_isTracingMode) {
-      // Add this tap as a dot marker.
-      final markerId = MarkerId(point.toString());
-      // Using a different hue for temporary markers.
-      final Marker marker = Marker(
-        markerId: markerId,
-        position: point,
-        icon: tempMarkerIcon,
-        anchor: const Offset(0.5, 0.9),
-      );
 
-      setState(() {
-        _tracingPoints.add(point);
-        _tracingMarkers.add(marker);
-      });
+    final markerId = MarkerId(point.toString());
+    final Marker marker = Marker(
+      markerId: markerId,
+      position: point,
+      icon: tempMarkerIcon,
+      anchor: const Offset(0.5, 0.9),
+    );
 
-      // Append the tapped point to the traced polyline.
-      Polyline? polyline = createPolyline(_tracingPoints, Colors.grey);
-      if (polyline == null) {
-        throw Exception('Failed to create Polyline from given points.');
-      }
+    setState(() {
+      _tracingPoints.add(point);
+      _tracingMarkers.add(marker);
+    });
 
-      setState(() {
-        _tracingPolyline = polyline;
-      });
+    // Rebuild polyline with new point.
+    Polyline? polyline = createPolyline(_tracingPoints, Colors.grey);
+    if (polyline == null) {
+      throw Exception('Failed to create Polyline from given points.');
     }
+
+    setState(() {
+      _tracingPolyline = polyline;
+    });
   }
 
   void _doActivityDataSheet() async {
@@ -250,8 +223,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
     if (activity == null) return;
 
     // Map the selected activity to its corresponding marker icon.
-    BitmapDescriptor connectorIcon = _getMarkerIcon(activity);
-
+    final AssetMapBitmap connectorIcon = activityInMotionIconMap[activity]!;
     final newPolyline = _tracingPolyline!.copyWith(colorParam: activity.color);
 
     // Create a data point from the polyline and activity
@@ -276,35 +248,46 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
         ),
       ]);
 
-      // Clear temp values previously holding polyline info and turn off tracing
-      _tracingPoints.clear();
-      _tracingMarkers.clear();
-      _tracingPolyline = null;
-      _isTracingMode = false;
+      _clearTracing();
     });
+  }
+
+  void _clearTracing() {
+    _tracingPoints.clear();
+    _tracingMarkers.clear();
+    _tracingPolyline = null;
   }
 
   void _startTest() {
     setState(() {
       _isTestRunning = true;
-      _remainingSeconds = 300; // Reset countdown value
     });
     _timer = Timer.periodic(Duration(seconds: 1), (timer) {
-      // TODO: extract the timer and necessary functionality to its own
-      // stateful widget to stop this from forcing the whole screen to
-      // need to rebuild every second.
       setState(() {
+        _remainingSeconds--;
         if (_remainingSeconds <= 0) {
+          _isTestRunning = false;
           timer.cancel();
-        } else {
-          _remainingSeconds--;
+          showDialog(
+            context: context,
+            builder: (context) {
+              return TimerEndDialog(onSubmit: () {
+                Navigator.pop(context);
+                _endTest();
+              }, onBack: () {
+                setState(() {
+                  _remainingSeconds = widget.activeTest.testDuration;
+                });
+                Navigator.pop(context);
+              });
+            },
+          );
         }
       });
     });
   }
 
-  void _endTest() async {
-    _isTestRunning = false;
+  void _endTest() {
     _timer?.cancel();
     widget.activeTest.submitData(_newData);
     Navigator.pop(context);
@@ -312,184 +295,156 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
 
   @override
   Widget build(BuildContext context) {
-    Set<Marker> visibleMarkers = {
-      ..._standingPointMarkers,
-      if (_tracingMarkers.isNotEmpty) ...{
-        _tracingMarkers.first,
-        _tracingMarkers.last,
-      },
-      ..._confirmedPolylineEndMarkers
-    };
-    return SafeArea(
+    return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
         appBar: AppBar(
           systemOverlayStyle:
               SystemUiOverlayStyle(statusBarBrightness: Brightness.light),
           backgroundColor: Colors.transparent,
-          elevation: 0,
-          leadingWidth: 100,
-          // Start/End button on the left.
-          leading: Padding(
-            padding: const EdgeInsets.only(left: 20, top: 4, bottom: 4),
-            child: ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                backgroundColor: _isTestRunning ? Colors.red : Colors.green,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
-                ),
-              ),
-              onPressed: () {
-                if (_isTestRunning) {
-                  _endTest();
-                } else {
-                  _startTest();
-                }
-              },
-              child: Text(
-                _isTestRunning ? 'End' : 'Start',
-                style: const TextStyle(color: Colors.white, fontSize: 16),
-              ),
-            ),
-          ),
-          // Persistent prompt in the middle.
-          title: _isTracingMode
-              ? Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.6),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    'Tap the screen to trace',
-                    textAlign: TextAlign.center,
-                    maxLines: 2,
-                    style: const TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                )
-              : null,
-          centerTitle: true,
-          // Timer on the right.
-          actions: [
-            Padding(
-              padding: const EdgeInsets.only(right: 20),
-              child: Center(
-                child: Container(
-                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.6),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    formatTime(_remainingSeconds),
-                    style: TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                ),
-              ),
-            )
-          ],
+          automaticallyImplyLeading: false,
+          forceMaterialTransparency: true,
         ),
         body: Stack(
           children: [
-            // Full-screen map with polylines.
             SizedBox(
-              height: MediaQuery.of(context).size.height,
+              height: MediaQuery.sizeOf(context).height,
               child: GoogleMap(
                 onMapCreated: _onMapCreated,
                 initialCameraPosition: CameraPosition(
                   target: _location,
                   zoom: _zoom,
                 ),
-                markers: visibleMarkers,
+                markers: {
+                  ..._standingPointMarkers,
+                  if (_tracingMarkers.isNotEmpty) ...{
+                    _tracingMarkers.first,
+                    _tracingMarkers.last,
+                  },
+                  ..._confirmedPolylineEndMarkers
+                },
                 polygons: _polygons,
                 polylines: {
                   ..._confirmedPolylines,
                   if (_tracingPolyline != null) _tracingPolyline!
                 },
-                onTap: (_isTracingMode) ? _handleMapTap : null,
+                onTap:
+                    (_isTestRunning && _isTracingMode) ? _handleMapTap : null,
                 mapType: _currentMapType,
                 myLocationButtonEnabled: false,
               ),
             ),
-
-            if (_showErrorMessage) OutsideBoundsWarning(),
-            // Buttons in top right corner of map below timer.
-            // Button for toggling map type.
-            Positioned(
-              top: MediaQuery.of(context).padding.top + kToolbarHeight + 8.0,
-              right: 20.0,
-              child: CircularIconMapButton(
-                backgroundColor: const Color(0xFF7EAD80).withValues(alpha: 0.9),
-                borderColor: Color(0xFF2D6040),
-                onPressed: _toggleMapType,
-                icon: Center(
-                  child: Icon(Icons.layers, color: Color(0xFF2D6040)),
-                ),
-              ),
-            ),
-            // Button for toggling instructions.
-            if (!_isLoading)
-              Positioned(
-                top: MediaQuery.of(context).padding.top + kToolbarHeight + 70.0,
-                right: 20,
-                child: CircularIconMapButton(
-                  backgroundColor: Color(0xFFBACFEB).withValues(alpha: 0.9),
-                  borderColor: Color(0xFF37597D),
-                  onPressed: _showInstructionOverlay,
-                  icon: Center(
-                    child: Icon(
-                      FontAwesomeIcons.info,
-                      color: Color(0xFF37597D),
-                    ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      setState(() {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                            _clearTracing();
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      });
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
                 ),
-              ),
-            // Button for toggling points menu.
-            Positioned(
-              top: MediaQuery.of(context).padding.top + kToolbarHeight + 132.0,
-              right: 20.0,
-              child: CircularIconMapButton(
-                backgroundColor: Color(0xFFBD9FE4).withValues(alpha: 0.9),
-                borderColor: Color(0xFF5A3E85),
-                onPressed: () {
-                  setState(() {
-                    _isPointsMenuVisible = !_isPointsMenuVisible;
-                  });
-                },
-                icon: Icon(
-                  FontAwesomeIcons.locationDot,
-                  color: Color(0xFF5A3E85),
+                Expanded(
+                  child: _directionsVisible
+                      ? Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: 15.0),
+                          child: DirectionsText(
+                            onTap: () {
+                              setState(() {
+                                _directionsVisible = !_directionsVisible;
+                              });
+                            },
+                            text: 'Tap the screen to trace.',
+                          ),
+                        )
+                      : SizedBox(),
                 ),
-              ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 15, right: 15),
+                  child: Column(
+                    spacing: 10,
+                    children: <Widget>[
+                      DirectionsButton(
+                        onTap: () {
+                          setState(() {
+                            _directionsVisible = !_directionsVisible;
+                          });
+                        },
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            const Color(0xFF7EAD80).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF2D6040),
+                        onPressed: _toggleMapType,
+                        icon: Center(
+                          child: Icon(Icons.layers, color: Color(0xFF2D6040)),
+                        ),
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            Color(0xFFBACFEB).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF37597D),
+                        onPressed: _showInstructionOverlay,
+                        icon: Center(
+                          child: Icon(
+                            FontAwesomeIcons.info,
+                            color: Color(0xFF37597D),
+                          ),
+                        ),
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            Color(0xFFBD9FE4).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF5A3E85),
+                        onPressed: () {
+                          setState(() {
+                            _isPointsMenuVisible = !_isPointsMenuVisible;
+                          });
+                        },
+                        icon: Icon(
+                          FontAwesomeIcons.locationDot,
+                          color: Color(0xFF5A3E85),
+                        ),
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            Color(0xFFFF9800).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF8C2F00),
+                        onPressed: () {
+                          setState(() {
+                            _isTracingMode = !_isTracingMode;
+                            _clearTracing();
+                          });
+                        },
+                        icon: Icon(
+                          FontAwesomeIcons.pen,
+                          color: Color(0xFF8C2F00),
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              ],
             ),
-            // Button for activating tracing mode.
-            Positioned(
-              top: MediaQuery.of(context).padding.top + kToolbarHeight + 194.0,
-              right: 20.0,
-              child: CircularIconMapButton(
-                backgroundColor: Color(0xFFFF9800).withValues(alpha: 0.9),
-                borderColor: Color(0xFF8C2F00),
-                onPressed: () {
-                  setState(() {
-                    _isTracingMode = !_isTracingMode;
-                    _tracingPoints.clear();
-                    _tracingMarkers.clear();
-                    _tracingPolyline = null;
-                  });
-                },
-                icon: Icon(
-                  FontAwesomeIcons.pen,
-                  color: Color(0xFF8C2F00),
-                ),
+            if (_outsidePoint)
+              TestErrorText(
+                padding: EdgeInsets.symmetric(horizontal: 50, vertical: 150),
               ),
-            ),
             if (_isPointsMenuVisible)
               Center(
                 child: Padding(
@@ -582,9 +537,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
           ElevatedButton(
             onPressed: () {
               setState(() {
-                _tracingPoints.clear();
-                _tracingMarkers.clear();
-                _tracingPolyline = null;
+                _clearTracing();
                 _isTracingMode = false;
               });
             },

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -172,7 +172,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
   }
 
   // When in tracing mode, each tap creates a dot marker and updates the temporary polyline
-  Future<void> _handleMapTap(LatLng point) async {
+  void _handleMapTap(LatLng point) {
     // If point is outside the project boundary, display error message
     if (!isPointInsidePolygon(point, _polygons.first)) {
       setState(() {

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -223,7 +223,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
     if (activity == null) return;
 
     // Map the selected activity to its corresponding marker icon.
-    final AssetMapBitmap connectorIcon = activityInMotionIconMap[activity]!;
+    final AssetMapBitmap connectorIcon = peopleInMotionIconMap[activity]!;
     final newPolyline = _tracingPolyline!.copyWith(colorParam: activity.color);
 
     // Create a data point from the polyline and activity
@@ -270,6 +270,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
           timer.cancel();
           showDialog(
             context: context,
+            barrierDismissible: false,
             builder: (context) {
               return TimerEndDialog(onSubmit: () {
                 Navigator.pop(context);

--- a/lib/people_in_motion_test.dart
+++ b/lib/people_in_motion_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -294,6 +295,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
@@ -338,30 +340,33 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      setState(() {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                            _clearTracing();
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      });
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
+                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
+                  child: SizedBox(
+                    width: 75,
+                    child: TimerButtonAndDisplay(
+                      onPressed: () {
+                        setState(() {
+                          if (_isTestRunning) {
+                            setState(() {
+                              _isTestRunning = false;
+                              _timer?.cancel();
+                              _clearTracing();
+                            });
+                          } else {
+                            _startTest();
+                          }
+                        });
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
                   ),
                 ),
                 Expanded(
                   child: _directionsVisible
                       ? Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: 15.0),
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: topOverlayPadding),
                           child: DirectionsText(
                             onTap: () {
                               setState(() {
@@ -374,7 +379,7 @@ class _PeopleInMotionTestPageState extends State<PeopleInMotionTestPage> {
                       : SizedBox(),
                 ),
                 Padding(
-                  padding: const EdgeInsets.only(top: 15, right: 15),
+                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
                   child: Column(
                     spacing: 10,
                     children: <Widget>[

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -65,6 +65,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
         markerId: MarkerId(point.toString()),
         position: point.location,
         icon: standingPointDisabledIcon,
+        consumeTapEvents: true,
       ));
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -97,9 +98,9 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
             ),
             textAlign: TextAlign.center,
           ),
-          content: SizedBox(
-            width: MediaQuery.sizeOf(context).width,
-            child: SingleChildScrollView(
+          content: SingleChildScrollView(
+            child: SizedBox(
+              width: double.maxFinite,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -253,11 +254,11 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
         return layingFemaleMarker;
       case 'squatting_female':
         return squattingFemaleMarker;
-      case 'standing_nonbinary' || 'standing_unspecified':
+      case 'standing_unspecified':
         return standingNAMarker;
-      case 'sitting_nonbinary' || 'sitting_unspecified':
+      case 'sitting_unspecified':
         return sittingNAMarker;
-      case 'layingDown_nonbinary' || 'layingDown_unspecified':
+      case 'layingDown_unspecified':
         return layingNAMarker;
       default:
         return squattingNAMarker;
@@ -301,7 +302,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
+    return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
         appBar: AppBar(

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -32,7 +32,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
   bool _isTestRunning = false;
   bool _outsidePoint = false;
   bool _isPointsMenuVisible = false;
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
 
   double _zoom = 18;
   late GoogleMapController mapController;
@@ -310,24 +310,21 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
               children: <Widget>[
                 Padding(
                   padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: SizedBox(
-                    width: 75,
-                    child: TimerButtonAndDisplay(
-                      onPressed: () {
-                        setState(() {
-                          if (_isTestRunning) {
-                            setState(() {
-                              _isTestRunning = false;
-                              _timer?.cancel();
-                            });
-                          } else {
-                            _startTest();
-                          }
-                        });
-                      },
-                      isTestRunning: _isTestRunning,
-                      remainingSeconds: _remainingSeconds,
-                    ),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      setState(() {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      });
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
                 ),
                 Expanded(

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -186,8 +186,8 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
     }
 
     final MarkerId markerId = MarkerId(point.toString());
-    final key = '${person.posture.name}_${person.gender.name}';
-    AssetMapBitmap markerIcon = _getMarkerIcon(key);
+    AssetMapBitmap markerIcon =
+        peopleInPlaceIconMap[(person.posture, person.gender)]!;
 
     // Add this data point to set of visible markers and other data lists.
     setState(() {
@@ -236,35 +236,6 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
     }
   }
 
-  AssetMapBitmap _getMarkerIcon(String key) {
-    switch (key) {
-      case 'standing_male':
-        return standingMaleMarker;
-      case 'sitting_male':
-        return sittingMaleMarker;
-      case 'layingDown_male':
-        return layingMaleMarker;
-      case 'squatting_male':
-        return squattingMaleMarker;
-      case 'standing_female':
-        return standingFemaleMarker;
-      case 'sitting_female':
-        return sittingFemaleMarker;
-      case 'layingDown_female':
-        return layingFemaleMarker;
-      case 'squatting_female':
-        return squattingFemaleMarker;
-      case 'standing_unspecified':
-        return standingNAMarker;
-      case 'sitting_unspecified':
-        return sittingNAMarker;
-      case 'layingDown_unspecified':
-        return layingNAMarker;
-      default:
-        return squattingNAMarker;
-    }
-  }
-
   void _startTest() {
     setState(() {
       _isTestRunning = true;
@@ -277,6 +248,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
           timer.cancel();
           showDialog(
             context: context,
+            barrierDismissible: false,
             builder: (context) {
               return TimerEndDialog(onSubmit: () {
                 Navigator.pop(context);

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -276,17 +275,17 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
 
   @override
   Widget build(BuildContext context) {
-    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
-    return AdaptiveSafeArea(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: (_currentMapType == MapType.normal)
+          ? SystemUiOverlayStyle.dark.copyWith(
+              statusBarColor: Colors.transparent,
+            )
+          : SystemUiOverlayStyle.light.copyWith(
+              statusBarColor: Colors.transparent,
+            ),
       child: Scaffold(
-        extendBodyBehindAppBar: true,
-        appBar: AppBar(
-          systemOverlayStyle:
-              SystemUiOverlayStyle(statusBarBrightness: Brightness.light),
-          backgroundColor: Colors.transparent,
-          automaticallyImplyLeading: false,
-          forceMaterialTransparency: true,
-        ),
+        resizeToAvoidBottomInset: false,
+        extendBody: true,
         body: Stack(
           children: [
             SizedBox(
@@ -304,96 +303,93 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
                 myLocationButtonEnabled: false,
               ),
             ),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      setState(() {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      });
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
-                  ),
-                ),
-                Expanded(
-                  child: _directionsVisible
-                      ? Padding(
-                          padding: EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: topOverlayPadding),
-                          child: DirectionsText(
-                            onTap: () {
-                              setState(() {
-                                _directionsVisible = !_directionsVisible;
-                              });
-                            },
-                            text: 'Tap to log data point.',
-                          ),
-                        )
-                      : SizedBox(),
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
-                  child: Column(
-                    spacing: 10,
-                    children: <Widget>[
-                      DirectionsButton(
-                        onTap: () {
-                          setState(() {
-                            _directionsVisible = !_directionsVisible;
-                          });
-                        },
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            const Color(0xFF7EAD80).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF2D6040),
-                        onPressed: _toggleMapType,
-                        icon: Center(
-                          child: Icon(Icons.layers, color: Color(0xFF2D6040)),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    TimerButtonAndDisplay(
+                      onPressed: () {
+                        setState(() {
+                          if (_isTestRunning) {
+                            setState(() {
+                              _isTestRunning = false;
+                              _timer?.cancel();
+                            });
+                          } else {
+                            _startTest();
+                          }
+                        });
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
+                    SizedBox(width: 15),
+                    Expanded(
+                      child: _directionsVisible
+                          ? DirectionsText(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
+                              text: 'Tap to log data point.',
+                            )
+                          : SizedBox(),
+                    ),
+                    SizedBox(width: 15),
+                    Column(
+                      spacing: 10,
+                      children: <Widget>[
+                        DirectionsButton(
+                          onTap: () {
+                            setState(() {
+                              _directionsVisible = !_directionsVisible;
+                            });
+                          },
                         ),
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            Color(0xFFBACFEB).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF37597D),
-                        onPressed: _showInstructionOverlay,
-                        icon: Center(
-                          child: Icon(
-                            FontAwesomeIcons.info,
-                            color: Color(0xFF37597D),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              const Color(0xFF7EAD80).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: Center(
+                            child: Icon(Icons.layers, color: Color(0xFF2D6040)),
                           ),
                         ),
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            Color(0xFFBD9FE4).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF5A3E85),
-                        onPressed: () {
-                          setState(() {
-                            _isPointsMenuVisible = !_isPointsMenuVisible;
-                          });
-                        },
-                        icon: Icon(
-                          FontAwesomeIcons.locationDot,
-                          color: Color(0xFF5A3E85),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFFBACFEB).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF37597D),
+                          onPressed: _showInstructionOverlay,
+                          icon: Center(
+                            child: Icon(
+                              FontAwesomeIcons.info,
+                              color: Color(0xFF37597D),
+                            ),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                )
-              ],
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFFBD9FE4).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF5A3E85),
+                          onPressed: () {
+                            setState(() {
+                              _isPointsMenuVisible = !_isPointsMenuVisible;
+                            });
+                          },
+                          icon: Icon(
+                            FontAwesomeIcons.locationDot,
+                            color: Color(0xFF5A3E85),
+                          ),
+                        ),
+                      ],
+                    )
+                  ],
+                ),
+              ),
             ),
             if (_outsidePoint)
               TestErrorText(

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -86,10 +86,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          insetPadding: EdgeInsets.symmetric(
-            horizontal: 10,
-            vertical: 10,
-          ),
+          insetPadding: const EdgeInsets.all(10),
           actionsPadding: EdgeInsets.zero,
           title: Text(
             'How It Works:',

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -275,6 +276,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
@@ -307,29 +309,32 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      setState(() {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      });
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
+                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
+                  child: SizedBox(
+                    width: 75,
+                    child: TimerButtonAndDisplay(
+                      onPressed: () {
+                        setState(() {
+                          if (_isTestRunning) {
+                            setState(() {
+                              _isTestRunning = false;
+                              _timer?.cancel();
+                            });
+                          } else {
+                            _startTest();
+                          }
+                        });
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
                   ),
                 ),
                 Expanded(
                   child: _directionsVisible
                       ? Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: 15.0),
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: topOverlayPadding),
                           child: DirectionsText(
                             onTap: () {
                               setState(() {
@@ -342,7 +347,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
                       : SizedBox(),
                 ),
                 Padding(
-                  padding: const EdgeInsets.only(top: 15, right: 15),
+                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
                   child: Column(
                     spacing: 10,
                     children: <Widget>[

--- a/lib/people_in_place_test.dart
+++ b/lib/people_in_place_test.dart
@@ -47,6 +47,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
 
   int _remainingSeconds = -1;
   Timer? _timer;
+  Timer? _outsidePointTimer;
 
   MarkerId? _openMarkerId;
 
@@ -77,6 +78,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
   @override
   void dispose() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     super.dispose();
   }
 
@@ -173,12 +175,12 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
       builder: (context) => _DescriptionForm(location: point),
     );
     if (person == null) {
-      if (_outsidePoint) {
-        await Future.delayed(const Duration(seconds: 2));
+      _outsidePointTimer?.cancel();
+      _outsidePointTimer = Timer(Duration(seconds: 3), () {
         setState(() {
           _outsidePoint = false;
         });
-      }
+      });
       return;
     }
 
@@ -225,10 +227,11 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
     });
 
     if (_outsidePoint) {
-      // TODO: fix delay. delay will overlap with consecutive taps.
-      await Future.delayed(const Duration(seconds: 2));
-      setState(() {
-        _outsidePoint = false;
+      _outsidePointTimer?.cancel();
+      _outsidePointTimer = Timer(Duration(seconds: 3), () {
+        setState(() {
+          _outsidePoint = false;
+        });
       });
     }
   }
@@ -265,6 +268,7 @@ class _PeopleInPlaceTestPageState extends State<PeopleInPlaceTestPage> {
 
   void _endTest() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     widget.activeTest.submitData(_newData);
     Navigator.pop(context);
   }

--- a/lib/project_details_page.dart
+++ b/lib/project_details_page.dart
@@ -1,15 +1,15 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:p2bp_2025spring_mobile/show_project_options_dialog.dart';
-import 'db_schema_classes.dart';
 import 'package:flutter/services.dart';
-import 'package:p2bp_2025spring_mobile/create_test_form.dart';
-import 'package:p2bp_2025spring_mobile/theme.dart';
-import 'firestore_functions.dart';
-import 'package:intl/intl.dart';
-import 'package:p2bp_2025spring_mobile/acoustic_profile_test.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:intl/intl.dart';
+import 'package:p2bp_2025spring_mobile/create_test_form.dart';
+import 'package:p2bp_2025spring_mobile/show_project_options_dialog.dart';
+import 'package:p2bp_2025spring_mobile/theme.dart';
+
+import 'db_schema_classes.dart';
+import 'firestore_functions.dart';
 import 'mini_map.dart';
 
 class ProjectDetailsPage extends StatefulWidget {
@@ -255,9 +255,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
   void _showCreateTestModal() async {
     final Map<String, dynamic>? newTestInfo = await showModalBottomSheet(
       context: context,
-      isScrollControlled: true, // allows the sheet to be fully draggable
-      backgroundColor:
-          Colors.transparent, // makes the sheet's corners rounded if desired
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
       builder: (BuildContext context) {
         return DraggableScrollableSheet(
           initialChildSize: 0.7,
@@ -275,15 +274,13 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
               child: CreateTestForm(
                 activeProject: widget.projectData,
               ),
-              // Replace this ListView with your desired content
             );
           },
         );
       },
     );
     if (newTestInfo == null) return;
-    final Test test;
-    test = await saveTest(
+    final Test test = await saveTest(
       title: newTestInfo['title'],
       scheduledTime: newTestInfo['scheduledTime'],
       projectRef:
@@ -294,6 +291,12 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
           : null,
       testDuration: newTestInfo.containsKey('testDuration')
           ? newTestInfo['testDuration']
+          : null,
+      intervalDuration: newTestInfo.containsKey('intervalDuration')
+          ? newTestInfo['intervalDuration']
+          : null,
+      intervalCount: newTestInfo.containsKey('intervalCount')
+          ? newTestInfo['intervalCount']
           : null,
     );
     setState(() {
@@ -367,14 +370,10 @@ class TestCard extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Row(
-                          children: [
-                            Text(
-                              test.title,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(fontWeight: FontWeight.bold),
-                            ),
-                          ],
+                        Text(
+                          test.title,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(fontWeight: FontWeight.bold),
                         ),
                         Row(
                           children: [

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -53,7 +53,7 @@ class _SectionCutterState extends State<SectionCutter> {
   final Set<Polygon> _polygons = {};
   Set<Polyline> _polyline = {};
   List<LatLng> _sectionPoints = [];
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
 
   Project? project;
 

--- a/lib/section_cutter_test.dart
+++ b/lib/section_cutter_test.dart
@@ -1,17 +1,16 @@
-import 'dart:io';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:p2bp_2025spring_mobile/firestore_functions.dart';
 import 'package:p2bp_2025spring_mobile/theme.dart';
 import 'package:p2bp_2025spring_mobile/widgets.dart';
-import 'project_details_page.dart';
+
 import 'db_schema_classes.dart';
 import 'google_maps_functions.dart';
-import 'package:file_selector/file_selector.dart';
-
 import 'home_screen.dart';
+import 'project_details_page.dart';
 
 class SectionCutter extends StatefulWidget {
   final Project activeProject;
@@ -41,7 +40,7 @@ class _SectionCutterState extends State<SectionCutter> {
   String _directions =
       "Go to designated section. Then upload the section drawing here.";
   XFile? sectionCutterFile;
-  final double _bottomSheetHeight = Platform.isIOS ? 325 : 300;
+  static const double _bottomSheetHeight = 315;
   late DocumentReference teamRef;
 
   double _zoom = 18;
@@ -102,277 +101,304 @@ class _SectionCutterState extends State<SectionCutter> {
 
   @override
   Widget build(BuildContext context) {
-    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
-    return AdaptiveSafeArea(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: (_currentMapType == MapType.normal)
+          ? SystemUiOverlayStyle.dark.copyWith(
+              statusBarColor: Colors.transparent,
+            )
+          : SystemUiOverlayStyle.light.copyWith(
+              statusBarColor: Colors.transparent,
+            ),
       child: Scaffold(
         resizeToAvoidBottomInset: false,
         extendBody: true,
-        body: Center(
-          child: Stack(
-            children: [
-              SizedBox(
-                height: MediaQuery.of(context).size.height,
-                child: GoogleMap(
-                  // TODO: size based off of bottomsheet container
-                  padding: EdgeInsets.only(bottom: _bottomSheetHeight),
-                  onMapCreated: _onMapCreated,
-                  initialCameraPosition:
-                      CameraPosition(target: _location, zoom: _zoom),
-                  polygons: _polygons,
-                  polylines: _polyline,
-                  mapType: _currentMapType, // Use current map type
-                ),
+        body: Stack(
+          children: [
+            SizedBox(
+              height: MediaQuery.sizeOf(context).height,
+              child: GoogleMap(
+                padding: EdgeInsets.only(bottom: _bottomSheetHeight),
+                onMapCreated: _onMapCreated,
+                initialCameraPosition:
+                    CameraPosition(target: _location, zoom: _zoom),
+                polygons: _polygons,
+                polylines: _polyline,
+                mapType: _currentMapType,
+                myLocationButtonEnabled: false,
               ),
-              Positioned(
-                top: topOverlayPadding,
-                left: 15.0,
-                child: DirectionsButton(
-                  onTap: () {
-                    setState(() {
-                      _directionsVisible = !_directionsVisible;
-                    });
-                  },
-                ),
-              ),
-              Align(
-                alignment: Alignment.bottomLeft,
-                child: Padding(
-                  padding:
-                      EdgeInsets.only(bottom: _bottomSheetHeight + 50, left: 5),
-                  child: FloatingActionButton(
-                    heroTag: null,
-                    onPressed: _toggleMapType,
-                    backgroundColor: Colors.green,
-                    child: const Icon(Icons.map),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-        bottomSheet: Container(
-          height: _bottomSheetHeight,
-          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
-          decoration: BoxDecoration(
-            gradient: defaultGrad,
-            borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(24.0),
-              topRight: Radius.circular(24.0),
             ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black,
-                offset: Offset(0.0, 1.0), //(x,y)
-                blurRadius: 6.0,
-              ),
-            ],
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              SizedBox(height: 5),
-              Text(
-                'Section Cutter',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  color: placeYellow,
-                ),
-              ),
-              Text(
-                'Upload your section drawing here.',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontStyle: FontStyle.italic,
-                  color: Colors.grey[400],
-                ),
-              ),
-              SizedBox(height: 35),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    flex: 1,
-                    child: SizedBox(),
-                  ),
-                  _isLoadingUpload
-                      ? const Center(child: CircularProgressIndicator())
-                      : Expanded(
-                          flex: 2,
-                          child: FilledButton.icon(
-                            onPressed: () async {
-                              sectionCutterFile = await openFile(
-                                acceptedTypeGroups: <XTypeGroup>[
-                                  acceptedFileTypes
-                                ],
-                              );
-                              setState(() {
-                                _isLoadingUpload = true;
-                              });
-                              if (sectionCutterFile != null) {
-                                // save to firebase
-                                setState(() {
-                                  _failedToUpload = false;
-                                  _uploaded = true;
-                                  _directions = "Click finish to finish test.";
-                                });
-                              } else {
-                                setState(() {
-                                  _failedToUpload = true;
-                                  _errorText = 'Failed to upload new image.';
-                                });
-                                print("No file selected");
-                              }
-                              setState(() {
-                                _isLoadingUpload = false;
-                              });
-                            },
-                            label: Text(
-                              'Upload File',
-                              style: TextStyle(
-                                  fontSize: 20, fontWeight: FontWeight.bold),
-                            ),
-                            icon: _uploaded
-                                ? Icon(Icons.check)
-                                : Icon(Icons.upload_file),
-                            iconAlignment: IconAlignment.end,
-                            style: FilledButton.styleFrom(
-                              padding: EdgeInsets.symmetric(
-                                  vertical: 20, horizontal: 20),
-                              backgroundColor: Colors.white,
-                              foregroundColor: Colors.black,
-                              iconColor: Colors.black,
-                              iconSize: 25,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(10.0),
-                              ),
-                            ),
-                          ),
-                        ),
-                  Expanded(
-                    flex: 1,
-                    child: (_uploaded && !_isLoadingUpload)
-                        ? Align(
-                            alignment: Alignment.centerLeft,
-                            child: IconButton(
-                              onPressed: () {
-                                if (sectionCutterFile != null) {
-                                  sectionCutterFile = null;
-                                }
-                                setState(() {
-                                  _failedToUpload = false;
-                                  _uploaded = false;
-                                  _directions =
-                                      "Go to designated section. Then upload the section drawing here.";
-                                });
-                              },
-                              icon: Icon(Icons.cancel),
-                              color: Colors.red[700],
-                            ),
-                          )
-                        : SizedBox(),
-                  ),
-                ],
-              ),
-              SizedBox(height: 5),
-              _failedToUpload
-                  ? Padding(
-                      padding: const EdgeInsets.only(left: 12.0),
-                      child: Text.rich(
-                        TextSpan(
-                          text: _errorText,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 2,
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontStyle: FontStyle.italic,
-                          color: Colors.red,
-                        ),
-                      ),
-                    )
-                  : SizedBox(),
-              SizedBox(height: 5),
-              Text(
-                'Accepted formats: .png, .pdf, .jpg',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontStyle: FontStyle.italic,
-                  color: Colors.grey[400],
-                ),
-              ),
-              SizedBox(height: 20),
-              Expanded(
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
                 child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  spacing: 10,
                   children: <Widget>[
-                    EditButton(
-                      text: 'Back',
-                      foregroundColor: Colors.black,
-                      backgroundColor: Colors.white,
-                      onPressed: _isLoadingUpload
-                          ? null
-                          : () => Navigator.pop(context, 'Back'),
-                      iconAlignment: IconAlignment.start,
-                      icon: Icon(Icons.chevron_left, color: Colors.black),
-                    ),
-                    Flexible(
-                      flex: 1,
-                      child: EditButton(
-                        text: 'Finish',
-                        foregroundColor: Colors.black,
-                        backgroundColor: Colors.white,
-                        icon: const Icon(Icons.chevron_right,
-                            color: Colors.black),
-                        onPressed: _isLoadingUpload
-                            ? null
-                            : () async {
-                                final bool finishSuccess = await showDialog(
-                                    context: context,
-                                    builder: (context) {
-                                      return TestFinishDialog(onNext: () async {
-                                        if (sectionCutterFile == null) {
-                                          Navigator.pop(context, false);
-                                          setState(() {
-                                            _failedToUpload = true;
-                                            _errorText =
-                                                'No file uploaded. Please upload an image first.';
-                                          });
-                                          print("No file uploaded.");
-                                          return;
-                                        }
-                                        Navigator.pop(context, true);
-                                      });
-                                    });
-                                if (finishSuccess) {
-                                  setState(() {
-                                    _isLoadingUpload = true;
-                                  });
-                                  Section data = await widget.activeTest!
-                                      .saveXFile(sectionCutterFile!);
-                                  widget.activeTest!.submitData(data);
-                                  if (!context.mounted) return;
-                                  Navigator.pushReplacement(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) => HomeScreen(),
-                                      ));
-                                  Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) =>
-                                            ProjectDetailsPage(
-                                                projectData:
-                                                    widget.activeProject),
-                                      ));
-                                }
+                    Expanded(
+                      child: _directionsVisible
+                          ? DirectionsText(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
                               },
-                      ),
+                              text: _directions,
+                            )
+                          : SizedBox(),
+                    ),
+                    SizedBox(width: 15),
+                    Column(
+                      spacing: 10,
+                      children: <Widget>[
+                        DirectionsButton(
+                          onTap: () {
+                            setState(() {
+                              _directionsVisible = !_directionsVisible;
+                            });
+                          },
+                        ),
+                        CircularIconMapButton(
+                          backgroundColor: Colors.green,
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: const Icon(Icons.map),
+                        ),
+                      ],
                     ),
                   ],
                 ),
-              )
-            ],
+              ),
+            ),
+          ],
+        ),
+        bottomSheet: SizedBox(
+          height: _bottomSheetHeight,
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+            decoration: BoxDecoration(
+              gradient: defaultGrad,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(24.0),
+                topRight: Radius.circular(24.0),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black,
+                  offset: Offset(0.0, 1.0),
+                  blurRadius: 6.0,
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                SizedBox(height: 5),
+                Text(
+                  'Section Cutter',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: placeYellow,
+                  ),
+                ),
+                Text(
+                  'Upload your section drawing here.',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontStyle: FontStyle.italic,
+                    color: Colors.grey[400],
+                  ),
+                ),
+                SizedBox(height: 35),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      flex: 1,
+                      child: SizedBox(),
+                    ),
+                    _isLoadingUpload
+                        ? const Center(child: CircularProgressIndicator())
+                        : Expanded(
+                            flex: 2,
+                            child: FilledButton.icon(
+                              onPressed: () async {
+                                sectionCutterFile = await openFile(
+                                  acceptedTypeGroups: <XTypeGroup>[
+                                    acceptedFileTypes
+                                  ],
+                                );
+                                setState(() {
+                                  _isLoadingUpload = true;
+                                });
+                                if (sectionCutterFile != null) {
+                                  // save to firebase
+                                  setState(() {
+                                    _failedToUpload = false;
+                                    _uploaded = true;
+                                    _directions =
+                                        "Click finish to finish test.";
+                                  });
+                                } else {
+                                  setState(() {
+                                    _failedToUpload = true;
+                                    _errorText = 'Failed to upload new image.';
+                                  });
+                                  print("No file selected");
+                                }
+                                setState(() {
+                                  _isLoadingUpload = false;
+                                });
+                              },
+                              label: Text(
+                                'Upload File',
+                                style: TextStyle(
+                                    fontSize: 20, fontWeight: FontWeight.bold),
+                              ),
+                              icon: _uploaded
+                                  ? Icon(Icons.check)
+                                  : Icon(Icons.upload_file),
+                              iconAlignment: IconAlignment.end,
+                              style: FilledButton.styleFrom(
+                                padding: EdgeInsets.symmetric(
+                                    vertical: 20, horizontal: 20),
+                                backgroundColor: Colors.white,
+                                foregroundColor: Colors.black,
+                                iconColor: Colors.black,
+                                iconSize: 25,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10.0),
+                                ),
+                              ),
+                            ),
+                          ),
+                    Expanded(
+                      flex: 1,
+                      child: (_uploaded && !_isLoadingUpload)
+                          ? Align(
+                              alignment: Alignment.centerLeft,
+                              child: IconButton(
+                                onPressed: () {
+                                  if (sectionCutterFile != null) {
+                                    sectionCutterFile = null;
+                                  }
+                                  setState(() {
+                                    _failedToUpload = false;
+                                    _uploaded = false;
+                                    _directions =
+                                        "Go to designated section. Then upload the section drawing here.";
+                                  });
+                                },
+                                icon: Icon(Icons.cancel),
+                                color: Colors.red[700],
+                              ),
+                            )
+                          : SizedBox(),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 5),
+                _failedToUpload
+                    ? Padding(
+                        padding: const EdgeInsets.only(left: 12.0),
+                        child: Text.rich(
+                          TextSpan(
+                            text: _errorText,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 2,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontStyle: FontStyle.italic,
+                            color: Colors.red,
+                          ),
+                        ),
+                      )
+                    : SizedBox(),
+                SizedBox(height: 5),
+                Text(
+                  'Accepted formats: .png, .pdf, .jpg',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontStyle: FontStyle.italic,
+                    color: Colors.grey[400],
+                  ),
+                ),
+                SizedBox(height: 20),
+                Expanded(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    spacing: 10,
+                    children: <Widget>[
+                      EditButton(
+                        text: 'Back',
+                        foregroundColor: Colors.black,
+                        backgroundColor: Colors.white,
+                        onPressed: _isLoadingUpload
+                            ? null
+                            : () => Navigator.pop(context, 'Back'),
+                        iconAlignment: IconAlignment.start,
+                        icon: Icon(Icons.chevron_left, color: Colors.black),
+                      ),
+                      Flexible(
+                        flex: 1,
+                        child: EditButton(
+                          text: 'Finish',
+                          foregroundColor: Colors.black,
+                          backgroundColor: Colors.white,
+                          icon: const Icon(Icons.chevron_right,
+                              color: Colors.black),
+                          onPressed: _isLoadingUpload
+                              ? null
+                              : () async {
+                                  final bool finishSuccess = await showDialog(
+                                      context: context,
+                                      builder: (context) {
+                                        return TestFinishDialog(
+                                            onNext: () async {
+                                          if (sectionCutterFile == null) {
+                                            Navigator.pop(context, false);
+                                            setState(() {
+                                              _failedToUpload = true;
+                                              _errorText =
+                                                  'No file uploaded. Please upload an image first.';
+                                            });
+                                            print("No file uploaded.");
+                                            return;
+                                          }
+                                          Navigator.pop(context, true);
+                                        });
+                                      });
+                                  if (finishSuccess) {
+                                    setState(() {
+                                      _isLoadingUpload = true;
+                                    });
+                                    Section data = await widget.activeTest
+                                        .saveXFile(sectionCutterFile!);
+                                    widget.activeTest.submitData(data);
+                                    if (!context.mounted) return;
+                                    Navigator.pushReplacement(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => HomeScreen(),
+                                        ));
+                                    Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) =>
+                                              ProjectDetailsPage(
+                                                  projectData:
+                                                      widget.activeProject),
+                                        ));
+                                  }
+                                },
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/spatial_boundaries_instructions.dart
+++ b/lib/spatial_boundaries_instructions.dart
@@ -148,11 +148,12 @@ Widget spatialBoundariesInstructions() {
               border: Border.all(color: Color(0xFF4A5D75), width: 2),
             ),
             child: Center(
-                child: Transform.translate(
-              offset: Offset(-1, 0),
-              child: Icon(FontAwesomeIcons.solidEyeSlash,
-                  size: 13, color: Color(0xFF4A5D75)),
-            )),
+              child: Icon(
+                Icons.visibility_off,
+                size: 15,
+                color: Color(0xFF4A5D75),
+              ),
+            ),
           ),
         ),
         TextSpan(
@@ -219,44 +220,45 @@ Widget buildLegends() {
             runSpacing: spacing,
             children: [
               legendItem(
-                  Icons.layers,
-                  "Toggle Map View",
-                  const Color.fromARGB(255, 126, 173, 128)
-                      .withValues(alpha: 0.9),
-                  BoxShape.circle,
-                  Border.all(color: const Color(0xFF2D6040), width: 2),
-                  const Color(0xFF2D6040),
-                  itemWidth),
+                Icons.layers,
+                "Toggle Map View",
+                const Color.fromARGB(255, 126, 173, 128).withValues(alpha: 0.9),
+                BoxShape.circle,
+                Border.all(color: const Color(0xFF2D6040), width: 2),
+                const Color(0xFF2D6040),
+                itemWidth,
+              ),
               legendItem(
-                  FontAwesomeIcons.info,
-                  "Toggle Instructions",
-                  const Color.fromARGB(255, 186, 207, 235)
-                      .withValues(alpha: 0.9),
-                  BoxShape.circle,
-                  Border.all(
-                    color: const Color(0xFF37597D),
-                    width: 2,
-                  ),
-                  const Color(0xFF37597D),
-                  itemWidth),
+                FontAwesomeIcons.info,
+                "Toggle Instructions",
+                const Color.fromARGB(255, 186, 207, 235).withValues(alpha: 0.9),
+                BoxShape.circle,
+                Border.all(
+                  color: const Color(0xFF37597D),
+                  width: 2,
+                ),
+                const Color(0xFF37597D),
+                itemWidth,
+              ),
               legendItem(
-                  Icons.shape_line_rounded,
-                  "Recorded Boundaries",
-                  const Color.fromARGB(255, 189, 159, 228)
-                      .withValues(alpha: 0.9),
-                  BoxShape.circle,
-                  Border.all(color: const Color(0xFF5A3E85), width: 2),
-                  const Color(0xFF5A3E85),
-                  itemWidth),
+                Icons.shape_line_rounded,
+                "Recorded Boundaries",
+                const Color.fromARGB(255, 189, 159, 228).withValues(alpha: 0.9),
+                BoxShape.circle,
+                Border.all(color: const Color(0xFF5A3E85), width: 2),
+                const Color(0xFF5A3E85),
+                itemWidth,
+              ),
               legendItem(
-                  FontAwesomeIcons.solidEyeSlash,
-                  "Toggle Visibility",
-                  const Color.fromARGB(255, 207, 211, 217),
-                  BoxShape.circle,
-                  Border.all(color: const Color(0xFF4A5D75), width: 2),
-                  const Color(0xFF4A5D75),
-                  itemWidth,
-                  iconOffset: Offset(-2, 0)),
+                Icons.visibility_off,
+                "Toggle Visibility",
+                const Color.fromARGB(255, 207, 211, 217),
+                BoxShape.circle,
+                Border.all(color: const Color(0xFF4A5D75), width: 2),
+                const Color(0xFF4A5D75),
+                itemWidth,
+                iconSize: 18,
+              ),
             ],
           ),
         ],
@@ -267,7 +269,7 @@ Widget buildLegends() {
 
 Widget legendItem(IconData icon, String label, Color buttonColor,
     BoxShape buttonShape, Border border, Color iconColor, double width,
-    {Offset iconOffset = Offset.zero}) {
+    {Offset iconOffset = Offset.zero, double iconSize = 15}) {
   return SizedBox(
     width: width,
     child: Row(
@@ -285,7 +287,7 @@ Widget legendItem(IconData icon, String label, Color buttonColor,
               offset: iconOffset,
               child: Icon(
                 icon,
-                size: 15,
+                size: iconSize,
                 color: iconColor,
               ),
             ),

--- a/lib/spatial_boundaries_test.dart
+++ b/lib/spatial_boundaries_test.dart
@@ -415,13 +415,6 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
     );
   }
 
-  /// Toggles the user's ability to see boundaries already defined on the map.
-  void _toggleBoundariesVisibility() {
-    setState(() {
-      _boundariesVisible = !_boundariesVisible;
-    });
-  }
-
   void _startTest() {
     setState(() {
       _isTestRunning = true;
@@ -455,6 +448,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
   /// Method to end the test and timer.
   void _endTest() {
     _timer?.cancel();
+    _outsidePointTimer?.cancel();
     widget.activeTest.submitData(_newData);
     Navigator.pop(context);
   }
@@ -568,15 +562,17 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
                         backgroundColor:
                             Color(0xFFE4E9EF).withValues(alpha: 0.9),
                         borderColor: Color(0xFF4A5D75),
-                        onPressed: _toggleBoundariesVisibility,
-                        icon: Transform.translate(
-                          offset: Offset(-2.0, 0),
-                          child: Icon(
-                            _boundariesVisible
-                                ? FontAwesomeIcons.solidEyeSlash
-                                : FontAwesomeIcons.solidEye,
-                            color: Color(0xFF4A5D75),
-                          ),
+                        onPressed: () {
+                          setState(() {
+                            _boundariesVisible = !_boundariesVisible;
+                          });
+                        },
+                        icon: Icon(
+                          _boundariesVisible
+                              ? Icons.visibility_off
+                              : Icons.visibility,
+                          size: 30,
+                          color: Color(0xFF4A5D75),
                         ),
                       ),
                     ],

--- a/lib/spatial_boundaries_test.dart
+++ b/lib/spatial_boundaries_test.dart
@@ -36,7 +36,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
   bool _outsidePoint = false;
   bool _boundariesVisible = true;
   bool _isTestRunning = false;
-  bool _directionsVisible = false;
+  bool _directionsVisible = true;
 
   int _remainingSeconds = -1;
   Timer? _timer;
@@ -499,25 +499,22 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
               children: <Widget>[
                 Padding(
                   padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: SizedBox(
-                    width: 75,
-                    child: TimerButtonAndDisplay(
-                      onPressed: () {
-                        setState(() {
-                          if (_isTestRunning) {
-                            setState(() {
-                              _isTestRunning = false;
-                              _timer?.cancel();
-                              _resetPlacementVariables();
-                            });
-                          } else {
-                            _startTest();
-                          }
-                        });
-                      },
-                      isTestRunning: _isTestRunning,
-                      remainingSeconds: _remainingSeconds,
-                    ),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      setState(() {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                            _resetPlacementVariables();
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      });
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
                 ),
                 Expanded(

--- a/lib/spatial_boundaries_test.dart
+++ b/lib/spatial_boundaries_test.dart
@@ -455,24 +455,17 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
 
   @override
   Widget build(BuildContext context) {
-    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
-    return AdaptiveSafeArea(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: (_currentMapType == MapType.normal)
+          ? SystemUiOverlayStyle.dark.copyWith(
+              statusBarColor: Colors.transparent,
+            )
+          : SystemUiOverlayStyle.light.copyWith(
+              statusBarColor: Colors.transparent,
+            ),
       child: Scaffold(
-        extendBodyBehindAppBar: true,
-        appBar: AppBar(
-          systemOverlayStyle: Platform.isIOS
-              ? (_currentMapType == MapType.normal
-                  ? SystemUiOverlayStyle.dark.copyWith(
-                      statusBarColor: Colors.transparent,
-                    )
-                  : SystemUiOverlayStyle.light.copyWith(
-                      statusBarColor: Colors.transparent,
-                    ))
-              : null,
-          backgroundColor: Colors.transparent,
-          automaticallyImplyLeading: false,
-          forceMaterialTransparency: true,
-        ),
+        resizeToAvoidBottomInset: false,
+        extendBody: true,
         body: Stack(
           children: <Widget>[
             SizedBox(
@@ -493,93 +486,90 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
                 myLocationButtonEnabled: false,
               ),
             ),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      setState(() {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                            _resetPlacementVariables();
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      });
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
-                  ),
-                ),
-                Expanded(
-                  child: _directionsVisible
-                      ? Padding(
-                          padding: EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: topOverlayPadding),
-                          child: DirectionsText(
-                            onTap: () {
-                              setState(() {
-                                _directionsVisible = !_directionsVisible;
-                              });
-                            },
-                            text: _directionsActive,
-                          ),
-                        )
-                      : SizedBox(),
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
-                  child: Column(
-                    spacing: 10,
-                    children: [
-                      DirectionsButton(
-                        onTap: () {
-                          setState(() {
-                            _directionsVisible = !_directionsVisible;
-                          });
-                        },
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            Color(0xFF7EAD80).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF2D6040),
-                        onPressed: _toggleMapType,
-                        icon: Icon(Icons.layers),
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            Color(0xFFBACFEB).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF37597D),
-                        onPressed: _showInstructionOverlay,
-                        icon: Icon(FontAwesomeIcons.info),
-                      ),
-                      CircularIconMapButton(
-                        backgroundColor:
-                            Color(0xFFE4E9EF).withValues(alpha: 0.9),
-                        borderColor: Color(0xFF4A5D75),
-                        onPressed: () {
-                          setState(() {
-                            _boundariesVisible = !_boundariesVisible;
-                          });
-                        },
-                        icon: Icon(
-                          _boundariesVisible
-                              ? Icons.visibility_off
-                              : Icons.visibility,
-                          size: 30,
-                          color: Color(0xFF4A5D75),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    TimerButtonAndDisplay(
+                      onPressed: () {
+                        setState(() {
+                          if (_isTestRunning) {
+                            setState(() {
+                              _isTestRunning = false;
+                              _timer?.cancel();
+                              _resetPlacementVariables();
+                            });
+                          } else {
+                            _startTest();
+                          }
+                        });
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
+                    SizedBox(width: 15),
+                    Expanded(
+                      child: _directionsVisible
+                          ? DirectionsText(
+                              onTap: () {
+                                setState(() {
+                                  _directionsVisible = !_directionsVisible;
+                                });
+                              },
+                              text: _directionsActive,
+                            )
+                          : SizedBox(),
+                    ),
+                    SizedBox(width: 15),
+                    Column(
+                      spacing: 10,
+                      children: [
+                        DirectionsButton(
+                          onTap: () {
+                            setState(() {
+                              _directionsVisible = !_directionsVisible;
+                            });
+                          },
                         ),
-                      ),
-                    ],
-                  ),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFF7EAD80).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF2D6040),
+                          onPressed: _toggleMapType,
+                          icon: Icon(Icons.layers),
+                        ),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFFBACFEB).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF37597D),
+                          onPressed: _showInstructionOverlay,
+                          icon: Icon(FontAwesomeIcons.info),
+                        ),
+                        CircularIconMapButton(
+                          backgroundColor:
+                              Color(0xFFE4E9EF).withValues(alpha: 0.9),
+                          borderColor: Color(0xFF4A5D75),
+                          onPressed: () {
+                            setState(() {
+                              _boundariesVisible = !_boundariesVisible;
+                            });
+                          },
+                          icon: Icon(
+                            _boundariesVisible
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                            size: 30,
+                            color: Color(0xFF4A5D75),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
             if (_outsidePoint)
               TestErrorText(

--- a/lib/spatial_boundaries_test.dart
+++ b/lib/spatial_boundaries_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:maps_toolkit/maps_toolkit.dart' as mp;
+import 'package:p2bp_2025spring_mobile/assets.dart';
 
 import 'db_schema_classes.dart';
 import 'firestore_functions.dart';
@@ -30,31 +31,30 @@ class SpatialBoundariesTestPage extends StatefulWidget {
 }
 
 class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
-  bool _isLoading = true;
   bool _polygonMode = false;
   bool _polylineMode = false;
   bool _outsidePoint = false;
   bool _boundariesVisible = true;
-  bool _isBoundariesMenuVisible = false;
-
   bool _isTestRunning = false;
-  int _remainingSeconds = 300;
+  bool _directionsVisible = false;
+
+  int _remainingSeconds = -1;
   Timer? _timer;
-  Timer? _hintTimer;
+  Timer? _outsidePointTimer;
 
   double _zoom = 18;
   late GoogleMapController mapController;
   LatLng _location = defaultLocation;
-  MapType _currentMapType = MapType.satellite; // Default map type
+  MapType _currentMapType = MapType.satellite;
   List<mp.LatLng> _projectArea = [];
 
   late final Polygon _projectPolygon; // Set for project polygon
-  final Set<Polygon> _polygons = {}; // Set of user-created polygons
-  final List<LatLng> _polygonPoints = []; // Points for the polygon
-  final Set<Marker> _polygonMarkers = {}; // Set of markers for polygon creation
+  final Set<Polygon> _polygons = {};
+  final List<LatLng> _polygonPoints = [];
+  final Set<Marker> _polygonMarkers = {};
   final Set<Polyline> _polylines = {};
-  final Set<Marker> _polylineMarkers = {};
   final List<LatLng> _polylinePoints = [];
+  final Set<Marker> _polylineMarkers = {};
 
   final SpatialBoundariesData _newData = SpatialBoundariesData();
   BoundaryType? _boundaryType;
@@ -64,13 +64,12 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
 
   static const List<String> _directionsList = [
     'Select a type of boundary.',
-    'Tap to place points outlining the boundary, then tap confirm when done.',
+    'Place points outlining the boundary and press confirm when you\'re done.',
   ];
   late String _directionsActive;
-  static const double _bottomSheetHeight = 320;
+  static const double _bottomSheetHeight = 220;
 
-  BitmapDescriptor?
-      polyNodeMarker; // Custom marker for plotting boundary points.
+  BitmapDescriptor? polyNodeMarker;
 
   @override
   void initState() {
@@ -79,31 +78,19 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
     _location = getPolygonCentroid(_projectPolygon);
     _projectArea = _projectPolygon.toMPLatLngList();
     _zoom = getIdealZoom(_projectArea, _location.toMPLatLng());
-    _isLoading = false;
+    _remainingSeconds = widget.activeTest.testDuration;
     _directionsActive = _directionsList[0];
     WidgetsBinding.instance.addPostFrameCallback((_) {
       print("PostFrameCallback fired");
-      _loadCustomMarker();
       _showInstructionOverlay();
     });
   }
 
-  /// Function to load custom marker icons using AssetMapBitmap.
-  Future<void> _loadCustomMarker() async {
-    final ImageConfiguration configuration =
-        createLocalImageConfiguration(context);
-    try {
-      polyNodeMarker = await AssetMapBitmap.create(
-        configuration,
-        'assets/temp_point_marker.png',
-        width: 40,
-        height: 40,
-      );
-
-      print("Custom markers loaded successfully.");
-    } catch (e) {
-      print("Error loading custom markers: $e");
-    }
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _outsidePointTimer?.cancel();
+    super.dispose();
   }
 
   void _onMapCreated(GoogleMapController controller) {
@@ -130,23 +117,21 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
   }
 
   /// Called whenever map is tapped
-  Future<void> _togglePoint(LatLng point) async {
+  void _togglePoint(LatLng point) {
     try {
-      if (!mp.PolygonUtil.containsLocation(
-          mp.LatLng(point.latitude, point.longitude), _projectArea, true)) {
+      if (!isPointInsidePolygon(point, _projectPolygon)) {
         setState(() {
           _outsidePoint = true;
+        });
+        _outsidePointTimer?.cancel();
+        _outsidePointTimer = Timer(Duration(seconds: 3), () {
+          setState(() {
+            _outsidePoint = false;
+          });
         });
       }
       if (_polygonMode) _polygonTap(point);
       if (_polylineMode) _polylineTap(point);
-      if (_outsidePoint) {
-        // TODO: fix delay. delay will overlap with consecutive taps. this means taps do not necessarily refresh the timer and will end prematurely
-        await Future.delayed(const Duration(seconds: 2));
-        setState(() {
-          _outsidePoint = false;
-        });
-      }
     } catch (e, stacktrace) {
       print('Error in spatial_boundaries_test.dart, _togglePoint(): $e');
       print('Stacktrace: $stacktrace');
@@ -162,11 +147,10 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
         Marker(
           markerId: markerId,
           position: point,
-          icon: polyNodeMarker ??
-              BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueBlue),
+          icon: tempMarkerIcon,
           consumeTapEvents: true,
           onTap: () {
-            // If the marker is tapped again, it will be removed
+            // If the marker is tapped again, it will be removed.
             setState(() {
               _polygonPoints.remove(point);
               _polygonMarkers
@@ -244,8 +228,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
         Marker(
           markerId: markerId,
           position: point,
-          icon: polyNodeMarker ??
-              BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueBlue),
+          icon: tempMarkerIcon,
           consumeTapEvents: true,
           onTap: () {
             // If the marker is tapped again, it will be removed
@@ -390,7 +373,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          insetPadding: EdgeInsets.all(10),
+          insetPadding: const EdgeInsets.all(10),
           actionsPadding: EdgeInsets.zero,
           title: const Text(
             'How It Works:',
@@ -439,18 +422,31 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
     });
   }
 
-  /// Method to start the test and timer
   void _startTest() {
     setState(() {
       _isTestRunning = true;
-      _remainingSeconds = 300;
     });
     _timer = Timer.periodic(Duration(seconds: 1), (timer) {
       setState(() {
+        _remainingSeconds--;
         if (_remainingSeconds <= 0) {
+          _isTestRunning = false;
           timer.cancel();
-        } else {
-          _remainingSeconds--;
+          showDialog(
+            context: context,
+            barrierDismissible: false,
+            builder: (context) {
+              return TimerEndDialog(onSubmit: () {
+                Navigator.pop(context);
+                _endTest();
+              }, onBack: () {
+                setState(() {
+                  _remainingSeconds = widget.activeTest.testDuration;
+                });
+                Navigator.pop(context);
+              });
+            },
+          );
         }
       });
     });
@@ -458,82 +454,9 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
 
   /// Method to end the test and timer.
   void _endTest() {
-    _isTestRunning = false;
     _timer?.cancel();
-    _hintTimer?.cancel();
     widget.activeTest.submitData(_newData);
     Navigator.pop(context);
-  }
-
-  /// Builds a custom AppBar widget that handles the Start/End button and duration timer for the test.
-  ///
-  /// Additionally, if the device platform is detected to be iOS, changes the status bar color to a white/black depending
-  /// on the current map mode to ensure the status bar color contrasts with the map background (unclear if necessary for Android given
-  /// the differences in the way the status bar is handled between both platforms).
-  AppBar _buildAppBar() {
-    return AppBar(
-      // Only apply systemOverlayStyle on iOS.
-      // Define the systemOverlayStyle based on map type.
-      systemOverlayStyle: Platform.isIOS
-          ? (_currentMapType == MapType.normal
-              // Sets a darker status bar in map view for better visibility.
-              ? SystemUiOverlayStyle.dark.copyWith(
-                  statusBarColor: Colors.transparent,
-                )
-              // Sets a lighter status bar in satellite view for better visibility.
-              : SystemUiOverlayStyle.light.copyWith(
-                  statusBarColor: Colors.transparent,
-                ))
-          : null,
-      toolbarHeight: kToolbarHeight + 10,
-      backgroundColor: Colors.transparent,
-      elevation: 0,
-      leadingWidth: 100,
-      // Start/End button on the left
-      leading: Padding(
-        padding: const EdgeInsets.only(top: 5, bottom: 5, left: 20),
-        child: ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            shape: RoundedRectangleBorder(
-              borderRadius:
-                  BorderRadius.circular(20), // Rounded rectangle shape.
-            ),
-            backgroundColor: _isTestRunning ? Colors.red : Colors.green,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          ),
-          onPressed: () {
-            if (_isTestRunning) {
-              _endTest();
-            } else {
-              _startTest();
-            }
-          },
-          child: Text(
-            _isTestRunning ? 'End' : 'Start',
-            style: const TextStyle(color: Colors.white, fontSize: 16),
-          ),
-        ),
-      ),
-      // Timer on the right
-      actions: [
-        Padding(
-          padding: const EdgeInsets.only(right: 20),
-          child: Center(
-            child: Container(
-              padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.6),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Text(
-                formatTime(_remainingSeconds),
-                style: TextStyle(color: Colors.white, fontSize: 16),
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
   }
 
   @override
@@ -541,381 +464,295 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
     return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
-        appBar: _buildAppBar(),
-        body: _isLoading
-            ? const Center(child: CircularProgressIndicator())
-            : Stack(
-                children: <Widget>[
-                  SizedBox(
-                    height: MediaQuery.sizeOf(context).height,
-                    child: GoogleMap(
-                      padding: EdgeInsets.only(bottom: _bottomSheetHeight),
-                      onMapCreated: _onMapCreated,
-                      initialCameraPosition:
-                          CameraPosition(target: _location, zoom: 15),
-                      markers: {..._polygonMarkers, ..._polylineMarkers},
-                      polygons: {
-                        _projectPolygon,
-                        if (_boundariesVisible) ..._polygons,
-                      },
-                      polylines: _boundariesVisible ? _polylines : <Polyline>{},
-                      onTap: _togglePoint,
-                      mapType: _currentMapType,
-                      myLocationButtonEnabled: false,
-                    ),
-                  ),
-                  Align(
-                    alignment: Alignment.topRight,
-                    child: Padding(
-                      padding:
-                          const EdgeInsets.only(top: kToolbarHeight, right: 20),
-                      child: Column(
-                        spacing: 10,
-                        children: [
-                          // Button for toggling the map mode
-                          CircularIconMapButton(
-                            backgroundColor:
-                                Color(0xFF7EAD80).withValues(alpha: 0.9),
-                            borderColor: Color(0xFF2D6040),
-                            onPressed: _toggleMapType,
-                            icon: Icon(Icons.layers),
-                          ),
-                          // Button for toggling instruction overlay
-                          CircularIconMapButton(
-                            backgroundColor:
-                                Color(0xFFBACFEB).withValues(alpha: 0.9),
-                            borderColor: Color(0xFF37597D),
-                            onPressed: _showInstructionOverlay,
-                            icon: Icon(FontAwesomeIcons.info),
-                          ),
-                          CircularIconMapButton(
-                            backgroundColor:
-                                Color(0xFFBD9FE4).withValues(alpha: 0.9),
-                            borderColor: Color(0xFF5A3E85),
-                            onPressed: () {
-                              setState(() {
-                                _isBoundariesMenuVisible =
-                                    !_isBoundariesMenuVisible;
-                              });
-                            },
-                            icon: Icon(
-                              Icons.shape_line,
-                              color: Color(0xFF5A3E85),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  // Button for toggling polygon/polyline visibility on the map
-                  Positioned(
-                    bottom: _bottomSheetHeight + 45,
-                    left: 10.0,
-                    child: CircularIconMapButton(
-                      backgroundColor: Color(0xFFE4E9EF).withValues(alpha: 0.9),
-                      borderColor: Color(0xFF4A5D75),
-                      onPressed: _toggleBoundariesVisibility,
-                      icon: Transform.translate(
-                        offset: Offset(-2.0, 0),
-                        child: Icon(
-                          _boundariesVisible
-                              ? FontAwesomeIcons.solidEyeSlash
-                              : FontAwesomeIcons.solidEye,
-                          color: Color(0xFF4A5D75),
-                        ),
-                      ),
-                    ),
-                  ),
-                  // Displays the list of confirmed boundaries and the color legend
-                  if (_isBoundariesMenuVisible)
-                    Padding(
-                      padding: EdgeInsets.only(
-                        top: kToolbarHeight + 20,
-                        bottom: _bottomSheetHeight + 30.0,
-                        left: 20.0,
-                        right: 20.0,
-                      ),
-                      child: DataEditMenu(
-                        title: 'Boundary Color Guide',
-                        colorLegendItems: [
-                          for (final type in BoundaryType.values)
-                            ColorLegendItem(
-                              label: type.displayName,
-                              color: type.color,
-                            ),
-                        ],
-                        placedDataList: _buildPlacedBoundariesList(),
-                        onPressedCloseMenu: () => setState(() =>
-                            _isBoundariesMenuVisible =
-                                !_isBoundariesMenuVisible),
-                        onPressedClearAll: () {},
-                      ),
-                    ),
-                ],
+        appBar: AppBar(
+          systemOverlayStyle: Platform.isIOS
+              ? (_currentMapType == MapType.normal
+                  ? SystemUiOverlayStyle.dark.copyWith(
+                      statusBarColor: Colors.transparent,
+                    )
+                  : SystemUiOverlayStyle.light.copyWith(
+                      statusBarColor: Colors.transparent,
+                    ))
+              : null,
+          backgroundColor: Colors.transparent,
+          automaticallyImplyLeading: false,
+          forceMaterialTransparency: true,
+        ),
+        body: Stack(
+          children: <Widget>[
+            SizedBox(
+              height: MediaQuery.sizeOf(context).height,
+              child: GoogleMap(
+                padding: EdgeInsets.only(bottom: _bottomSheetHeight),
+                onMapCreated: _onMapCreated,
+                initialCameraPosition:
+                    CameraPosition(target: _location, zoom: _zoom),
+                markers: {..._polygonMarkers, ..._polylineMarkers},
+                polygons: {
+                  _projectPolygon,
+                  if (_boundariesVisible) ..._polygons,
+                },
+                polylines: _boundariesVisible ? _polylines : <Polyline>{},
+                onTap: (_polygonMode || _polylineMode) ? _togglePoint : null,
+                mapType: _currentMapType,
+                myLocationButtonEnabled: false,
               ),
-        bottomSheet: _isLoading
-            ? SizedBox()
-            : SizedBox(
-                height: _bottomSheetHeight,
-                child: _buildBottomSheetStack(context),
-              ),
-      ),
-    );
-  }
-
-  /// (TODO) Builds the list of already placed boundary polygons/polylines
-  ListView _buildPlacedBoundariesList() {
-    // Returns an empty list to satisfy the required field of the Data Menu
-    return ListView();
-
-    // TODO: Adapt this code to work with SpatialBoundaries (I didn't want to mess with it and potentially
-    // break anything that's working perfectly fine as is).
-    //
-    // // Tracks how many elements of each type have been added so far.
-    // Map<ActivityTypeInMotion, int> typeCounter = {};
-    // return ListView.builder(
-    //   padding: EdgeInsets.zero,
-    //   itemCount: _newData.persons.length,
-    //   itemBuilder: (context, index) {
-    //     final person = _newData.persons[index];
-    //     // Increment this type's count
-    //     typeCounter.update(person.activity, (i) => i + 1, ifAbsent: () => 1);
-
-    //     return ListTile(
-    //       contentPadding: const EdgeInsets.symmetric(horizontal: 20),
-    //       title: Text(
-    //         '${person.activity.displayName} Route ${typeCounter[person.activity]}',
-    //         style: const TextStyle(fontWeight: FontWeight.bold),
-    //       ),
-    //       subtitle: Text(
-    //         'Points: ${person.polyline.points.length}',
-    //         textAlign: TextAlign.left,
-    //       ),
-    //       trailing: IconButton(
-    //         icon: const Icon(
-    //           FontAwesomeIcons.trashCan,
-    //           color: Color(0xFFD32F2F),
-    //         ),
-    //         onPressed: () {
-    //           setState(() {
-    //             // Delete this polyline and related objects from all sources.
-    //             _confirmedPolylineEndMarkers.removeWhere((marker) {
-    //               final points = person.polyline.points;
-    //               if (marker.markerId.value == points.first.toString() ||
-    //                   marker.markerId.value == points.last.toString()) {
-    //                 return true;
-    //               }
-    //               return false;
-    //             });
-    //             _confirmedPolylines.remove(person.polyline);
-    //             _newData.persons.remove(person);
-    //           });
-    //         },
-    //       ),
-    //     );
-    //   },
-    // );
-  }
-
-  Stack _buildBottomSheetStack(BuildContext context) {
-    return Stack(
-      children: [
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
-          decoration: BoxDecoration(
-            gradient: formGradient,
-            borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(24.0),
-              topRight: Radius.circular(24.0),
             ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black,
-                offset: Offset(0.0, 1.0), //(x,y)
-                blurRadius: 6.0,
-              ),
-            ],
-          ),
-          child: Column(
-            children: <Widget>[
-              Center(
-                child: Text(
-                  'Spatial Boundaries',
-                  softWrap: true,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: Color(0xFF2F6DCF),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
+                  child: TimerButtonAndDisplay(
+                    onPressed: () {
+                      setState(() {
+                        if (_isTestRunning) {
+                          setState(() {
+                            _isTestRunning = false;
+                            _timer?.cancel();
+                            _resetPlacementVariables();
+                          });
+                        } else {
+                          _startTest();
+                        }
+                      });
+                    },
+                    isTestRunning: _isTestRunning,
+                    remainingSeconds: _remainingSeconds,
                   ),
                 ),
+                Expanded(
+                  child: _directionsVisible
+                      ? Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: 15.0),
+                          child: DirectionsText(
+                            onTap: () {
+                              setState(() {
+                                _directionsVisible = !_directionsVisible;
+                              });
+                            },
+                            text: _directionsActive,
+                          ),
+                        )
+                      : SizedBox(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 15, right: 15),
+                  child: Column(
+                    spacing: 10,
+                    children: [
+                      DirectionsButton(
+                        onTap: () {
+                          setState(() {
+                            _directionsVisible = !_directionsVisible;
+                          });
+                        },
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            Color(0xFF7EAD80).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF2D6040),
+                        onPressed: _toggleMapType,
+                        icon: Icon(Icons.layers),
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            Color(0xFFBACFEB).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF37597D),
+                        onPressed: _showInstructionOverlay,
+                        icon: Icon(FontAwesomeIcons.info),
+                      ),
+                      CircularIconMapButton(
+                        backgroundColor:
+                            Color(0xFFE4E9EF).withValues(alpha: 0.9),
+                        borderColor: Color(0xFF4A5D75),
+                        onPressed: _toggleBoundariesVisibility,
+                        icon: Transform.translate(
+                          offset: Offset(-2.0, 0),
+                          child: Icon(
+                            _boundariesVisible
+                                ? FontAwesomeIcons.solidEyeSlash
+                                : FontAwesomeIcons.solidEye,
+                            color: Color(0xFF4A5D75),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            if (_outsidePoint)
+              TestErrorText(
+                padding:
+                    EdgeInsets.fromLTRB(50, 0, 50, _bottomSheetHeight + 20),
               ),
-              SizedBox(height: 15),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: Center(
+          ],
+        ),
+        bottomSheet: SizedBox(
+          height: _bottomSheetHeight,
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+            decoration: BoxDecoration(
+              gradient: formGradient,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(24.0),
+                topRight: Radius.circular(24.0),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black,
+                  offset: Offset(0.0, 1.0), //(x,y)
+                  blurRadius: 6.0,
+                ),
+              ],
+            ),
+            child: Column(
+              children: <Widget>[
+                Center(
                   child: Text(
-                    _directionsActive,
+                    'Spatial Boundaries',
                     softWrap: true,
                     textAlign: TextAlign.center,
                     style: TextStyle(
-                      fontSize: 16,
-                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: Color(0xFF2F6DCF),
                     ),
                   ),
                 ),
-              ),
-              SizedBox(height: 5),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                spacing: 10,
-                children: <Widget>[
-                  Expanded(
-                    flex: 11,
-                    child: FilledButton(
-                      style: testButtonStyle,
-                      onPressed: (_polygonMode || _polylineMode)
-                          ? null
-                          : () {
-                              _doConstructedModal(context);
-                            },
-                      child: Text('Constructed'),
-                    ),
-                  ),
-                  Expanded(
-                    flex: 8,
-                    child: FilledButton(
-                      style: testButtonStyle,
-                      onPressed: (_polygonMode || _polylineMode)
-                          ? null
-                          : () {
-                              _doMaterialModal(context);
-                            },
-                      child: Text('Material'),
-                    ),
-                  ),
-                  Expanded(
-                    flex: 7,
-                    child: FilledButton(
-                      style: testButtonStyle,
-                      onPressed: (_polygonMode || _polylineMode)
-                          ? null
-                          : () {
-                              _doShelterModal(context);
-                            },
-                      child: Text('Shelter'),
-                    ),
-                  ),
-                ],
-              ),
-              SizedBox(height: 15),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                spacing: 15,
-                children: <Widget>[
-                  Expanded(
-                    flex: 9,
-                    child: EditButton(
-                      text: 'Confirm Shape',
-                      foregroundColor: Colors.green,
-                      backgroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(15)),
-                      icon: const Icon(Icons.check),
-                      iconColor: Colors.green,
-                      onPressed: (_polygonMode && _polygonPoints.length >= 3)
-                          ? _finalizePolygon
-                          : (_polylineMode && _polylinePoints.length >= 2)
-                              ? _finalizePolyline
-                              : null,
-                    ),
-                  ),
-                  Expanded(
-                    flex: 6,
-                    child: EditButton(
-                      text: 'Cancel',
-                      foregroundColor: Colors.red,
-                      backgroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(15)),
-                      icon: const Icon(Icons.cancel),
-                      iconColor: Colors.red,
-                      onPressed: (_polygonMode || _polylineMode)
-                          ? _resetPlacementVariables
-                          : null,
-                    ),
-                  ),
-                ],
-              ),
-              SizedBox(height: 15),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                spacing: 10,
-                children: <Widget>[
-                  Flexible(
-                    child: FilledButton.icon(
-                      style: testButtonStyle,
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                      label: Text('Back'),
-                      icon: Icon(Icons.chevron_left),
-                      iconAlignment: IconAlignment.start,
-                    ),
-                  ),
-                  Flexible(
-                    child: FilledButton.icon(
-                      style: testButtonStyle,
-                      onPressed: (_polygonMode || _polylineMode)
-                          ? null
-                          : () {
-                              widget.activeTest.submitData(_newData);
-                              Navigator.pop(context);
-                            },
-                      label: Text('Finish'),
-                      icon: Icon(Icons.chevron_right),
-                      iconAlignment: IconAlignment.end,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        _outsidePoint
-            ? Align(
-                alignment: Alignment.bottomCenter,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                      vertical: 30.0, horizontal: 100.0),
-                  child: Container(
-                    padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-                    decoration: BoxDecoration(
-                      color: Colors.red[900],
-                      borderRadius: const BorderRadius.all(Radius.circular(10)),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.1),
-                          blurRadius: 6,
-                          offset: const Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Text(
-                      'You have placed a point outside of the project area!',
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w500,
-                        color: Colors.red[50],
+                SizedBox(height: 5),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  spacing: 10,
+                  children: <Widget>[
+                    Expanded(
+                      flex: 11,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed:
+                            (_isTestRunning && !_polygonMode && !_polylineMode)
+                                ? () {
+                                    _doConstructedModal(context);
+                                  }
+                                : null,
+                        child: Text('Constructed'),
                       ),
                     ),
-                  ),
+                    Expanded(
+                      flex: 8,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed:
+                            (_isTestRunning && !_polygonMode && !_polylineMode)
+                                ? () {
+                                    _doMaterialModal(context);
+                                  }
+                                : null,
+                        child: Text('Material'),
+                      ),
+                    ),
+                    Expanded(
+                      flex: 7,
+                      child: FilledButton(
+                        style: testButtonStyle,
+                        onPressed:
+                            (_isTestRunning && !_polygonMode && !_polylineMode)
+                                ? () {
+                                    _doShelterModal(context);
+                                  }
+                                : null,
+                        child: Text('Shelter'),
+                      ),
+                    ),
+                  ],
                 ),
-              )
-            : SizedBox(),
-      ],
+                SizedBox(height: 5),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  spacing: 15,
+                  children: <Widget>[
+                    Expanded(
+                      flex: 9,
+                      child: EditButton(
+                        text: 'Confirm Shape',
+                        foregroundColor: Colors.green,
+                        backgroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(15)),
+                        icon: const Icon(Icons.check),
+                        iconColor: Colors.green,
+                        onPressed: (_polygonMode && _polygonPoints.length >= 3)
+                            ? _finalizePolygon
+                            : (_polylineMode && _polylinePoints.length >= 2)
+                                ? _finalizePolyline
+                                : null,
+                      ),
+                    ),
+                    Expanded(
+                      flex: 6,
+                      child: EditButton(
+                        text: 'Cancel',
+                        foregroundColor: Colors.red,
+                        backgroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(15)),
+                        icon: const Icon(Icons.cancel),
+                        iconColor: Colors.red,
+                        onPressed: (_polygonMode || _polylineMode)
+                            ? _resetPlacementVariables
+                            : null,
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 15),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  spacing: 10,
+                  children: <Widget>[
+                    Flexible(
+                      child: FilledButton.icon(
+                        style: testButtonStyle,
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        label: Text('Back'),
+                        icon: Icon(Icons.chevron_left),
+                        iconAlignment: IconAlignment.start,
+                      ),
+                    ),
+                    Flexible(
+                      child: FilledButton.icon(
+                        style: testButtonStyle,
+                        onPressed:
+                            (!_polygonMode && !_polylineMode && !_isTestRunning)
+                                ? () {
+                                    showDialog(
+                                      context: context,
+                                      builder: (context) =>
+                                          TestFinishDialog(onNext: () {
+                                        Navigator.pop(context);
+                                        _endTest();
+                                      }),
+                                    );
+                                  }
+                                : null,
+                        label: Text('Finish'),
+                        icon: Icon(Icons.chevron_right),
+                        iconAlignment: IconAlignment.end,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/spatial_boundaries_test.dart
+++ b/lib/spatial_boundaries_test.dart
@@ -67,7 +67,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
     'Place points outlining the boundary and press confirm when you\'re done.',
   ];
   late String _directionsActive;
-  static const double _bottomSheetHeight = 220;
+  static final double _bottomSheetHeight = Platform.isIOS ? 250 : 220;
 
   BitmapDescriptor? polyNodeMarker;
 
@@ -455,6 +455,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double topOverlayPadding = Platform.isIOS ? 60 : 15.0;
     return AdaptiveSafeArea(
       child: Scaffold(
         extendBodyBehindAppBar: true,
@@ -497,30 +498,33 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.only(top: 15.0, left: 15.0),
-                  child: TimerButtonAndDisplay(
-                    onPressed: () {
-                      setState(() {
-                        if (_isTestRunning) {
-                          setState(() {
-                            _isTestRunning = false;
-                            _timer?.cancel();
-                            _resetPlacementVariables();
-                          });
-                        } else {
-                          _startTest();
-                        }
-                      });
-                    },
-                    isTestRunning: _isTestRunning,
-                    remainingSeconds: _remainingSeconds,
+                  padding: EdgeInsets.only(top: topOverlayPadding, left: 15.0),
+                  child: SizedBox(
+                    width: 75,
+                    child: TimerButtonAndDisplay(
+                      onPressed: () {
+                        setState(() {
+                          if (_isTestRunning) {
+                            setState(() {
+                              _isTestRunning = false;
+                              _timer?.cancel();
+                              _resetPlacementVariables();
+                            });
+                          } else {
+                            _startTest();
+                          }
+                        });
+                      },
+                      isTestRunning: _isTestRunning,
+                      remainingSeconds: _remainingSeconds,
+                    ),
                   ),
                 ),
                 Expanded(
                   child: _directionsVisible
                       ? Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 15.0, vertical: 15.0),
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 15.0, vertical: topOverlayPadding),
                           child: DirectionsText(
                             onTap: () {
                               setState(() {
@@ -533,7 +537,7 @@ class _SpatialBoundariesTestPageState extends State<SpatialBoundariesTestPage> {
                       : SizedBox(),
                 ),
                 Padding(
-                  padding: const EdgeInsets.only(top: 15, right: 15),
+                  padding: EdgeInsets.only(top: topOverlayPadding, right: 15),
                   child: Column(
                     spacing: 10,
                     children: [

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -5,6 +5,9 @@ import 'package:p2bp_2025spring_mobile/custom_material_colors.dart';
 /// Default color used when test buttons are disabled.
 const Color disabledGrey = Color(0xCD6C6C6C);
 
+/// Disabled button color with no transparency.
+const Color disabledGreyAlt = Color(0xFF5A5A5A);
+
 /// Transparency for test hint text (or, the directions at the top of the
 /// test map screen).
 const Color directionsTransparency = Color(0xDFDDE6F2);

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -399,7 +399,7 @@ class TimerButtonAndDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 66,
+      width: 75,
       child: Column(children: <Widget>[
         ElevatedButton(
           style: ElevatedButton.styleFrom(

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -400,36 +400,44 @@ class TimerButtonAndDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       width: 75,
-      child: Column(children: <Widget>[
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            disabledBackgroundColor: disabledGreyAlt,
-            disabledForegroundColor: Colors.grey,
-            foregroundColor: Colors.white,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+      child: Column(
+        children: <Widget>[
+          Center(
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                disabledBackgroundColor: disabledGreyAlt,
+                disabledForegroundColor: Colors.grey,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                backgroundColor: isTestRunning ? Colors.red : Colors.green,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              ),
+              onPressed: onPressed,
+              child: Text(
+                isTestRunning ? 'Stop' : 'Start',
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 16),
+              ),
             ),
-            backgroundColor: isTestRunning ? Colors.red : Colors.green,
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
           ),
-          onPressed: onPressed,
-          child: Text(
-            isTestRunning ? 'Stop' : 'Start',
-            style: const TextStyle(fontSize: 16),
+          Center(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.6),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                textAlign: TextAlign.center,
+                formatTime(remainingSeconds),
+                style: TextStyle(color: Colors.white, fontSize: 16),
+              ),
+            ),
           ),
-        ),
-        Container(
-          padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: Colors.black.withValues(alpha: 0.6),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Text(
-            formatTime(remainingSeconds),
-            style: TextStyle(color: Colors.white, fontSize: 16),
-          ),
-        ),
-      ]),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -403,6 +403,9 @@ class TimerButtonAndDisplay extends StatelessWidget {
       child: Column(children: <Widget>[
         ElevatedButton(
           style: ElevatedButton.styleFrom(
+            disabledBackgroundColor: disabledGreyAlt,
+            disabledForegroundColor: Colors.grey,
+            foregroundColor: Colors.white,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8),
             ),
@@ -412,7 +415,7 @@ class TimerButtonAndDisplay extends StatelessWidget {
           onPressed: onPressed,
           child: Text(
             isTestRunning ? 'Stop' : 'Start',
-            style: const TextStyle(color: Colors.white, fontSize: 16),
+            style: const TextStyle(fontSize: 16),
           ),
         ),
         Container(

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -392,7 +392,7 @@ class TimerButtonAndDisplay extends StatelessWidget {
     required this.remainingSeconds,
   });
 
-  final VoidCallback onPressed;
+  final void Function()? onPressed;
   final bool isTestRunning;
   final int remainingSeconds;
 
@@ -830,7 +830,7 @@ class DirectionsText extends StatelessWidget {
           child: Text(
             text,
             textAlign: TextAlign.center,
-            maxLines: 3,
+            maxLines: 5,
             overflow: TextOverflow.ellipsis,
             style: TextStyle(
               fontSize: 18,


### PR DESCRIPTION
Lots of little changes related to interval timer test 'type' added for Acoustic Profile's interval timer, as well as some more changes to how assets are setup. Layouts updated. Identifying Access and Section Cutter are the only two tests that I didn't change in some way either in this PR or in the related changes merged before this.

Also I believe I fixed the inconsistent logic behind the warning for placing a point outside the project polygon relating to how long to keep it visible, now using a 3 second timer rather than a 2 second delayed future.