### PR TITLE
Admin Checking and Project Address

### DIFF
--- a/lib/create_project_and_teams.dart
+++ b/lib/create_project_and_teams.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:p2bp_2025spring_mobile/project_map_creation.dart';
 import 'package:p2bp_2025spring_mobile/teams_and_invites_page.dart';
@@ -18,8 +17,6 @@ class CreateProjectAndTeamsPage extends StatefulWidget {
   State<CreateProjectAndTeamsPage> createState() =>
       _CreateProjectAndTeamsPageState();
 }
-
-User? loggedInUser = FirebaseAuth.instance.currentUser;
 
 class _CreateProjectAndTeamsPageState extends State<CreateProjectAndTeamsPage> {
   PageView page = PageView.project;
@@ -109,6 +106,7 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
   // TODO: add cover photo?
   String projectDescription = '';
   String projectTitle = '';
+  String projectAddress = '';
   final _formKey = GlobalKey<FormState>();
 
   @override
@@ -125,6 +123,7 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 25),
             child: Column(
+              spacing: 5,
               children: <Widget>[
                 Align(
                   alignment: Alignment.centerLeft,
@@ -138,7 +137,6 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     ),
                   ),
                 ),
-                const SizedBox(height: 5),
                 PhotoUpload(
                   width: 380,
                   height: 130,
@@ -150,7 +148,7 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     return;
                   },
                 ),
-                const SizedBox(height: 15.0),
+                const SizedBox(height: 10.0),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: Text(
@@ -163,7 +161,6 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     ),
                   ),
                 ),
-                const SizedBox(height: 5),
                 CreationTextBox(
                   maxLength: 60,
                   labelText: 'Project Name',
@@ -178,7 +175,6 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     });
                   },
                 ),
-                const SizedBox(height: 10.0),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: Text(
@@ -191,7 +187,6 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     ),
                   ),
                 ),
-                const SizedBox(height: 5),
                 CreationTextBox(
                   maxLength: 240,
                   labelText: 'Project Description',
@@ -206,6 +201,47 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     });
                   },
                 ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    spacing: 5,
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Project Address',
+                        textAlign: TextAlign.left,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16.0,
+                          color: Colors.blue[900],
+                        ),
+                      ),
+                      Tooltip(
+                        triggerMode: TooltipTriggerMode.tap,
+                        enableTapToDismiss: true,
+                        showDuration: Duration(seconds: 3),
+                        preferBelow: false,
+                        message:
+                            'Enter a central address for the designated project location. \nIf no such address exists, give an approximate location.',
+                        child:
+                            Icon(Icons.help, size: 18, color: Colors.blue[900]),
+                      ),
+                    ],
+                  ),
+                ),
+                CreationTextBox(
+                  maxLength: 120,
+                  labelText: 'Project Address',
+                  maxLines: 2,
+                  minLines: 2,
+                  errorMessage:
+                      'Project address must be at least 3 characters long.',
+                  onChanged: (addressText) {
+                    setState(() {
+                      projectAddress = addressText;
+                    });
+                  },
+                ),
                 const SizedBox(height: 10.0),
                 Align(
                   alignment: Alignment.bottomRight,
@@ -216,7 +252,6 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                     icon: const Icon(Icons.chevron_right),
                     onPressed: () async {
                       if (await getCurrentTeam() == null) {
-                        // TODO: Display error for creating project before team
                         if (!context.mounted) return;
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(
@@ -225,8 +260,10 @@ class _CreateProjectWidgetState extends State<CreateProjectWidget> {
                         );
                       } else if (_formKey.currentState!.validate()) {
                         Project partialProject = Project.partialProject(
-                            title: projectTitle,
-                            description: projectDescription);
+                          title: projectTitle,
+                          description: projectDescription,
+                          address: projectAddress,
+                        );
                         if (!context.mounted) return;
                         Navigator.push(
                             context,

--- a/lib/db_schema_classes.dart
+++ b/lib/db_schema_classes.dart
@@ -63,9 +63,11 @@ class Team {
 class Project {
   Timestamp? creationTime;
   DocumentReference? teamRef;
+  DocumentReference? projectAdmin;
   String projectID = '';
   String title = '';
   String description = '';
+  String address = '';
   List<LatLng> polygonPoints = [];
   num polygonArea = 0;
   List<DocumentReference> testRefs = [];
@@ -75,9 +77,11 @@ class Project {
   Project({
     this.creationTime,
     required this.teamRef,
+    required this.projectAdmin,
     required this.projectID,
     required this.title,
     required this.description,
+    required this.address,
     required this.polygonPoints,
     required this.polygonArea,
     required this.standingPoints,
@@ -86,7 +90,8 @@ class Project {
   });
 
   // TODO: Eventually add Team Photo and Team Color
-  Project.partialProject({required this.title, required this.description});
+  Project.partialProject(
+      {required this.title, required this.description, required this.address});
 
   // TODO: Probably want to delete test if test reference is not found; however, functionality may be unnecessary if the implementation of deleting a test deletes it from the project also (which is ideal).
   /// Gets all fields for each [Test] in this [Project] and loads them

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -275,6 +275,7 @@ class _LoginFormState extends State<LoginForm> {
           // Email Input
           TextFormField(
             controller: _emailController,
+            style: TextStyle(color: Colors.white),
             decoration: InputDecoration(
               prefixIcon: Padding(
                 padding: EdgeInsets.only(left: 10, right: 30),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,8 @@ class MyApp extends StatelessWidget {
         '/create_project_details': (context) => ProjectDetailsPage(
               projectData: Project.partialProject(
                   title: 'No data sent',
-                  description: 'Accessed without project data'),
+                  description: 'Accessed without project data',
+                  address: 'No address set'),
             ),
         '/login': (context) => const LoginScreen(),
         '/signup': (context) => const SignUpScreen(),

--- a/lib/nature_prevalence_test.dart
+++ b/lib/nature_prevalence_test.dart
@@ -814,16 +814,17 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                       spacing: 10,
                       children: [
                         DisplayModalButton(
-                            onPressed: (_pointMode ||
-                                    _polygonMode ||
-                                    _deleteMode ||
-                                    !_isTestRunning)
-                                ? null
-                                : () {
-                                    showModalAnimal(context);
-                                  },
-                            text: 'Animal',
-                            icon: Icon(Icons.pets)),
+                          onPressed: (_pointMode ||
+                                  _polygonMode ||
+                                  _deleteMode ||
+                                  !_isTestRunning)
+                              ? null
+                              : () {
+                                  showModalWaterBody(context);
+                                },
+                          text: 'Body of Water',
+                          icon: Icon(Icons.water),
+                        ),
                         DisplayModalButton(
                             onPressed: (_pointMode ||
                                     _polygonMode ||
@@ -854,16 +855,17 @@ class _NaturePrevalenceState extends State<NaturePrevalence> {
                       spacing: 10,
                       children: [
                         DisplayModalButton(
-                            onPressed: (_pointMode ||
-                                    _polygonMode ||
-                                    _deleteMode ||
-                                    !_isTestRunning)
-                                ? null
-                                : () {
-                                    showModalWaterBody(context);
-                                  },
-                            text: 'Body of Water',
-                            icon: Icon(Icons.water)),
+                          onPressed: (_pointMode ||
+                                  _polygonMode ||
+                                  _deleteMode ||
+                                  !_isTestRunning)
+                              ? null
+                              : () {
+                                  showModalAnimal(context);
+                                },
+                          text: 'Animal',
+                          icon: Icon(Icons.pets),
+                        ),
                       ],
                     ),
                     SizedBox(height: 20),

--- a/lib/project_details_page.dart
+++ b/lib/project_details_page.dart
@@ -31,7 +31,6 @@ User? loggedInUser = FirebaseAuth.instance.currentUser;
 class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
   late int _testCount;
   bool _isLoading = true;
-  Project? project;
   late Widget _testListView;
   late GoogleMapController mapController;
 
@@ -213,21 +212,22 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  FilledButton.icon(
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.only(left: 15, right: 15),
-                      backgroundColor: Color(0xFF62B6FF),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
+                  if (widget.projectData.projectAdmin!.id == loggedInUser!.uid)
+                    FilledButton.icon(
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.only(left: 15, right: 15),
+                        backgroundColor: Color(0xFF62B6FF),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10.0),
+                        ),
+                        // foregroundColor: foregroundColor,
+                        // backgroundColor: backgroundColor,
                       ),
-                      // foregroundColor: foregroundColor,
-                      // backgroundColor: backgroundColor,
-                    ),
-                    onPressed: _showCreateTestModal,
-                    label: Text('Create'),
-                    icon: Icon(Icons.add),
-                    iconAlignment: IconAlignment.end,
-                  )
+                      onPressed: _showCreateTestModal,
+                      label: Text('Create'),
+                      icon: Icon(Icons.add),
+                      iconAlignment: IconAlignment.end,
+                    )
                 ],
               ),
             ),
@@ -244,7 +244,10 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> {
                       ? _testListView
                       : const Center(
                           child: Text(
-                              'No research activities. Create one first!')),
+                            'No research activities. Create one first!',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
             ),
           ],
         ),

--- a/lib/project_map_creation.dart
+++ b/lib/project_map_creation.dart
@@ -19,8 +19,6 @@ class ProjectMapCreation extends StatefulWidget {
   State<ProjectMapCreation> createState() => _ProjectMapCreationState();
 }
 
-final User? loggedInUser = FirebaseAuth.instance.currentUser;
-
 class _ProjectMapCreationState extends State<ProjectMapCreation> {
   late DocumentReference teamRef;
   late GoogleMapController mapController;
@@ -368,11 +366,9 @@ class _ProjectMapCreationState extends State<ProjectMapCreation> {
                                               widget.partialProjectData.title,
                                           description: widget
                                               .partialProjectData.description,
-                                          teamRef: await getCurrentTeam(),
+                                          address:
+                                              widget.partialProjectData.address,
                                           polygonPoints: _polygons.first.points,
-                                          // Polygon area is square feet, returned in
-                                          // (meters)^2, multiplied by (feet/meter)^2
-                                          // TODO: move to constructor
                                           polygonArea: _polygons.first
                                               .getAreaInSquareFeet(),
                                           standingPoints: _standingPoints,

--- a/lib/search_location_screen.dart
+++ b/lib/search_location_screen.dart
@@ -349,7 +349,8 @@ class _SearchScreenState extends State<SearchScreen> {
                                 projectData: Project.partialProject(
                                     title: 'No data sent',
                                     description:
-                                        'Accessed without project data'),
+                                        'Accessed without project data',
+                                    address: 'No data found.'),
                               ),
                             ));
                       },

--- a/lib/teams_settings_screen.dart
+++ b/lib/teams_settings_screen.dart
@@ -53,8 +53,10 @@ class _TeamSettingsScreenState extends State<TeamSettingsScreen> {
       MaterialPageRoute(
         builder: (context) => ProjectDetailsPage(
           projectData: Project.partialProject(
-              title: 'No data sent',
-              description: 'Accessed without project data'),
+            title: 'No data sent',
+            description: 'Accessed without project data',
+            address: 'Accessed w/out project data',
+          ),
         ),
       ),
     );

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -276,6 +276,7 @@ class PasswordTextFormField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      style: TextStyle(color: Colors.white),
       obscureText: _obscureText,
       enableSuggestions: false,
       autocorrect: false,


### PR DESCRIPTION
- Added project address field when creating a project. Hooked up to the backend.
- Added project admin field automatically assigned to creator of project. Hooked up to the backend.
- Only admins can create tests in a project now.
- Visual changes include:
  - Spacing on project creation form changed from SizedBoxes to Column spacing
  - Changed text to white on login screen and research activity (when having 0 projects)
  - Create button only shows up if admin on project details.
- Removed some unused variables and imports from certain pages.
- Team ref no longer required on saveProject, instead is retrieved in function automatically.